### PR TITLE
[Markup] 내 계정 페이지(회원가입, 내계정 페이지 포함) 레이아웃 및 스타일링

### DIFF
--- a/frontend/public/css/login.css
+++ b/frontend/public/css/login.css
@@ -1,0 +1,26 @@
+:root {
+  --header-bg-color: #f6f6f6;
+}
+
+body {
+  padding: 0px;
+}
+
+.login-header {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--header-bg-color);
+  border-bottom: 1px solid #c0c0c0;
+  height: 10%;
+}
+
+.login-header--left {
+  position: absolute;
+  left: 20px;
+}
+
+.login-header--center--title {
+  font-size: 16px;
+  font-weight: 400;
+}

--- a/frontend/public/css/login.css
+++ b/frontend/public/css/login.css
@@ -40,7 +40,7 @@ body {
   padding-left: 15px;
   padding-right: 15px;
 }
-.login-main--id-input {
+.login-main--text-input {
   padding-right: 16px;
   padding-left: 16px;
   padding-top: 10px;
@@ -53,7 +53,7 @@ body {
   border-radius: 8px;
 }
 
-.login-main--login-btn {
+.login-main--submit-btn {
   margin-top: 24px;
   padding: 10px 16px;
   background-color: var(--primary1-color);
@@ -64,7 +64,7 @@ body {
   color: white;
 }
 
-.login-main--signup-btn {
+.login-main--link {
   margin-top: 34px;
   text-decoration: none;
   text-align: center;

--- a/frontend/public/css/login.css
+++ b/frontend/public/css/login.css
@@ -1,9 +1,13 @@
 :root {
   --header-bg-color: #f6f6f6;
+  --input-border-color: #d7d7d7;
+  --primary1-color: #2ac1bc;
 }
 
 body {
   padding: 0px;
+  display: flex;
+  flex-direction: column;
 }
 
 .login-header {
@@ -12,7 +16,7 @@ body {
   align-items: center;
   background-color: var(--header-bg-color);
   border-bottom: 1px solid #c0c0c0;
-  height: 10%;
+  height: 56px;
 }
 
 .login-header--left {
@@ -23,4 +27,47 @@ body {
 .login-header--center--title {
   font-size: 16px;
   font-weight: 400;
+}
+
+.login-main {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  background-color: white;
+  flex-grow: 1;
+  padding-top: 24px;
+  padding-left: 15px;
+  padding-right: 15px;
+}
+.login-main--id-input {
+  padding-right: 16px;
+  padding-left: 16px;
+  padding-top: 10px;
+  padding-bottom: 8px;
+
+  font-weight: 400;
+  font-size: 16px;
+
+  border: 1px solid var(--input-border-color);
+  border-radius: 8px;
+}
+
+.login-main--login-btn {
+  margin-top: 24px;
+  padding: 10px 16px;
+  background-color: var(--primary1-color);
+  border: none;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 500;
+  color: white;
+}
+
+.login-main--signup-btn {
+  margin-top: 34px;
+  text-decoration: none;
+  text-align: center;
+  color: black;
+  font-size: 14px;
+  font-weight: 500;
 }

--- a/frontend/public/css/normalize.css
+++ b/frontend/public/css/normalize.css
@@ -3,63 +3,143 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed, 
-figure, figcaption, footer, header, hgroup, 
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	box-sizing: border-box;
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
-    -webkit-tap-highlight-color: transparent;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+  -webkit-tap-highlight-color: transparent;
 }
 /* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure, 
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 
 html {
-    background-color: #fff;
+  background-color: #fff;
 }
 
 body {
-	position: relative;
-	line-height: 1;
-	font-size: 14px;
-    font-family: sans-serif;
-	height: 568px;
-	width: 320px;
-    margin: 0 auto;
-    padding: 20px 0;
-    background-color: #C0C0C0;
-    border: 1px solid;
-    overflow-y: scroll;
+  position: relative;
+  line-height: 1;
+  font-size: 14px;
+  font-family: sans-serif;
+  height: 568px;
+  width: 320px;
+  margin: 0 auto;
+  padding: 20px 0;
+  background-color: #c0c0c0;
+  overflow-y: scroll;
 }
-ol, ul {
-	list-style: none;
+ol,
+ul {
+  list-style: none;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }

--- a/frontend/public/css/profile.css
+++ b/frontend/public/css/profile.css
@@ -30,33 +30,27 @@ body {
   font-weight: 400;
 }
 
-.login-main {
+.profile-main {
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
   background-color: white;
   flex-grow: 1;
-  padding-top: 24px;
   padding-left: 15px;
   padding-right: 15px;
 }
-.login-main--text-input {
-  padding-right: 16px;
-  padding-left: 16px;
-  padding-top: 10px;
-  padding-bottom: 8px;
 
-  font-weight: 400;
-  font-size: 16px;
-
-  border: 1px solid var(--input-border-color);
-  border-radius: 8px;
+.profile-main--username {
+  text-align: center;
+  font-size: 14px;
+  font-weight: 500;
+  margin-top: 34px;
+  margin-bottom: 34px;
 }
 
-.login-main--submit-btn {
+.profile-main--logout-btn {
   text-decoration: none;
   text-align: center;
-  margin-top: 24px;
   padding: 10px 16px;
   background-color: var(--primary1-color);
   border: none;
@@ -64,13 +58,4 @@ body {
   font-size: 16px;
   font-weight: 500;
   color: white;
-}
-
-.login-main--link {
-  margin-top: 34px;
-  text-decoration: none;
-  text-align: center;
-  color: black;
-  font-size: 14px;
-  font-weight: 500;
 }

--- a/frontend/public/css/signup.css
+++ b/frontend/public/css/signup.css
@@ -6,9 +6,9 @@
 
 body {
   padding: 0px;
-  border: 1px solid #c0c0c0;
   display: flex;
   flex-direction: column;
+  border: 1px solid #c0c0c0;
 }
 
 .login-header {
@@ -30,7 +30,7 @@ body {
   font-weight: 400;
 }
 
-.login-main {
+.signup-main {
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
@@ -40,20 +40,25 @@ body {
   padding-left: 15px;
   padding-right: 15px;
 }
-.login-main--id-input {
+
+.signup-main--label {
+  padding: 5px;
+  margin-top: 16px;
+  font-size: 14px;
+  font-weight: 400;
+}
+.signup-main--text-input {
   padding-right: 16px;
   padding-left: 16px;
   padding-top: 10px;
   padding-bottom: 8px;
-
   font-weight: 400;
   font-size: 16px;
-
   border: 1px solid var(--input-border-color);
   border-radius: 8px;
 }
 
-.login-main--login-btn {
+.signup-main--submit-btn {
   margin-top: 24px;
   padding: 10px 16px;
   background-color: var(--primary1-color);
@@ -62,13 +67,4 @@ body {
   font-size: 16px;
   font-weight: 500;
   color: white;
-}
-
-.login-main--signup-btn {
-  margin-top: 34px;
-  text-decoration: none;
-  text-align: center;
-  color: black;
-  font-size: 14px;
-  font-weight: 500;
 }

--- a/frontend/public/login.html
+++ b/frontend/public/login.html
@@ -20,13 +20,13 @@
     </header>
     <main class="login-main">
       <input
-        class="login-main--id-input"
+        class="login-main--text-input"
         type="text"
         placeholder="아이디를 입력하세요"
       />
-      <input class="login-main--login-btn" type="button" value="로그인" />
+      <input class="login-main--submit-btn" type="button" value="로그인" />
 
-      <a class="login-main--signup-btn" href="signup.html">회원가입</a>
+      <a class="login-main--link" href="signup.html">회원가입</a>
     </main>
   </body>
 </html>

--- a/frontend/public/login.html
+++ b/frontend/public/login.html
@@ -26,7 +26,7 @@
       />
       <input class="login-main--login-btn" type="button" value="로그인" />
 
-      <a class="login-main--signup-btn" href="#">회원가입</a>
+      <a class="login-main--signup-btn" href="signup.html">회원가입</a>
     </main>
   </body>
 </html>

--- a/frontend/public/login.html
+++ b/frontend/public/login.html
@@ -4,9 +4,19 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
+    <link rel="stylesheet" href="/css/normalize.css" />
+    <link rel="stylesheet" href="/css/login.css" />
+
+    <title>로그인</title>
   </head>
   <body>
-    <h1>HELLO</h1>
+    <header class="login-header">
+      <a class="login-header--left" href="./main.html">
+        <img src="./icon/chevron-left.svg" />
+      </a>
+      <h1 class="login-header--center">
+        <span class="login-header--center--title"> 로그인 </span>
+      </h1>
+    </header>
   </body>
 </html>

--- a/frontend/public/login.html
+++ b/frontend/public/login.html
@@ -18,5 +18,15 @@
         <span class="login-header--center--title"> 로그인 </span>
       </h1>
     </header>
+    <main class="login-main">
+      <input
+        class="login-main--id-input"
+        type="text"
+        placeholder="아이디를 입력하세요"
+      />
+      <input class="login-main--login-btn" type="button" value="로그인" />
+
+      <a class="login-main--signup-btn" href="#">회원가입</a>
+    </main>
   </body>
 </html>

--- a/frontend/public/login.html
+++ b/frontend/public/login.html
@@ -24,7 +24,8 @@
         type="text"
         placeholder="아이디를 입력하세요"
       />
-      <input class="login-main--submit-btn" type="button" value="로그인" />
+
+      <a class="login-main--submit-btn" href="profile.html">로그인</a>
 
       <a class="login-main--link" href="signup.html">회원가입</a>
     </main>

--- a/frontend/public/profile.html
+++ b/frontend/public/profile.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/css/normalize.css" />
+    <link rel="stylesheet" href="/css/profile.css" />
+    <title>내 계정</title>
+  </head>
+  <body>
+    <header class="login-header">
+      <a class="login-header--left" href="./login.html">
+        <img src="./icon/chevron-left.svg" />
+      </a>
+      <h1 class="login-header--center">
+        <span class="login-header--center--title"> 내 계정 </span>
+      </h1>
+    </header>
+    <main class="profile-main">
+      <h1 class="profile-main--username">Username</h1>
+      <a class="profile-main--logout-btn" href="login.html">로그아웃</a>
+    </main>
+  </body>
+</html>

--- a/frontend/public/signup.html
+++ b/frontend/public/signup.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/css/normalize.css" />
+    <link rel="stylesheet" href="/css/signup.css" />
+
+    <title>회원가입</title>
+  </head>
+  <body>
+    <header class="login-header">
+      <a class="login-header--left" href="./login.html">
+        <img src="./icon/chevron-left.svg" />
+      </a>
+      <h1 class="login-header--center">
+        <span class="login-header--center--title"> 회원가입 </span>
+      </h1>
+    </header>
+    <main class="signup-main">
+      <label for="id-input" class="signup-main--label">아이디</label>
+      <input
+        id="id-input"
+        class="signup-main--text-input"
+        type="text"
+        placeholder="문자, 숫자 조합 20자 이상"
+      />
+
+      <label for="address-input" class="signup-main--label">우리 동네</label>
+      <input
+        id="address-input"
+        class="signup-main--text-input"
+        type="text"
+        placeholder="시-구 제외, 동만 입력"
+      />
+      <input class="signup-main--submit-btn" type="button" value="회원가입" />
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## 개요

내 계정 페이지 화면 레이아웃 구성 디자인 요구사항에 대한 PR입니다.

- [x] Login.html  퍼블리싱
- [x] Signup.html  퍼블리싱
- [x] Profile.html  퍼블리싱

## 변경사항


## 참고사항

각 화면별로 html 화면을 만들었습니다. 아마 중복되는 부분들은 javascript로 렌더링할 때 처리해야할 것 같습니다.
그점 유의해서 재사용가능한 스타일들은 코멘트를 남겨둬야할 것 같습니다.

## 추가 구현 필요사항

common 의 스타일을 조금 변경할 필요가 있어보이네요. body 가 vertical center할 필요가 잇어보입니다.

## 스크린샷

- 로그인 화면
<img width="339" alt="스크린샷 2021-07-13 오전 11 16 12" src="https://user-images.githubusercontent.com/20085849/125380052-948c7a80-e3cc-11eb-8cea-9d1483cc4a13.png">

- 회원가입 화면

<img width="341" alt="스크린샷 2021-07-13 오전 11 45 08" src="https://user-images.githubusercontent.com/20085849/125381950-c8b56a80-e3cf-11eb-9c78-ad786ce1dcf5.png">

- 프로필 화면

<img width="335" alt="스크린샷 2021-07-13 오전 11 55 27" src="https://user-images.githubusercontent.com/20085849/125382750-3910bb80-e3d1-11eb-9872-68bb304aed87.png">
