### PR TITLE
[Markdown] Category 화면관련 레이아웃 및 스타일 작업 내용입니다. #6

### DIFF
--- a/frontend/public/category.html
+++ b/frontend/public/category.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/css/normalize.css" />
+    <link rel="stylesheet" href="/css/category.css" />
+
+    <title>로그인</title>
+  </head>
+  <body>
+    <header class="header">
+      <a class="header--left" href="./main.html">
+        <img src="./icon/chevron-left.svg" />
+      </a>
+      <h1 class="header--center">
+        <span class="header--center--title"> 카테고리 </span>
+      </h1>
+    </header>
+    <main class="category-main">
+      <div class="category-main--card">
+        <div class="category-main--card--icon"></div>
+        <div class="category-main--card--title">디지털 기기</div>
+      </div>
+      <div class="category-main--card">
+        <div class="category-main--card--icon"></div>
+        <div class="category-main--card--title">생활 가전</div>
+      </div>
+      <div class="category-main--card">
+        <div class="category-main--card--icon"></div>
+        <div class="category-main--card--title">가구/인테리어</div>
+      </div>
+      <div class="category-main--card">
+        <div class="category-main--card--icon"></div>
+        <div class="category-main--card--title">게임/취미</div>
+      </div>
+      <div class="category-main--card">
+        <div class="category-main--card--icon"></div>
+        <div class="category-main--card--title">게임/취미</div>
+      </div>
+      <div class="category-main--card">
+        <div class="category-main--card--icon"></div>
+        <div class="category-main--card--title">게임/취미</div>
+      </div>
+      <div class="category-main--card">
+        <div class="category-main--card--icon"></div>
+        <div class="category-main--card--title">게임/취미</div>
+      </div>
+      <div class="category-main--card">
+        <div class="category-main--card--icon"></div>
+        <div class="category-main--card--title">게임/취미</div>
+      </div>
+      <div class="category-main--card">
+        <div class="category-main--card--icon"></div>
+        <div class="category-main--card--title">게임/취미</div>
+      </div>
+      <div class="category-main--card">
+        <div class="category-main--card--icon"></div>
+        <div class="category-main--card--title">게임/취미</div>
+      </div>
+      <div class="category-main--card">
+        <div class="category-main--card--icon"></div>
+        <div class="category-main--card--title">게임/취미</div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/frontend/public/css/category.css
+++ b/frontend/public/css/category.css
@@ -1,0 +1,69 @@
+@import url("./common/basic_header.css");
+@import url("./common/global_color.css");
+
+body {
+  padding: 0px;
+  border: 1px solid #c0c0c0;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--header-bg-color);
+  border-bottom: 1px solid #c0c0c0;
+  height: 56px;
+}
+
+.header--left {
+  position: absolute;
+  left: 20px;
+}
+
+.header--center--title {
+  font-size: 16px;
+  font-weight: 400;
+}
+
+.category-main {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  background-color: white;
+  padding-left: 15px;
+  padding-right: 15px;
+  align-content: flex-start;
+}
+
+.category-main::after {
+  content: "";
+  flex: auto;
+}
+
+.category-main--card {
+  width: 85px;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: space-between;
+  margin: 5px;
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
+.category-main--card--icon {
+  width: 40px;
+  height: 40px;
+  background-color: #c0c0c0;
+  border-radius: 8px;
+}
+
+.category-main--card--title {
+  margin-top: 16px;
+  text-align: center;
+  font-size: 12px;
+  font-weight: 400;
+}

--- a/frontend/public/css/common/basic_header.css
+++ b/frontend/public/css/common/basic_header.css
@@ -1,0 +1,18 @@
+.header {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--header-bg-color);
+  border-bottom: 1px solid #c0c0c0;
+  height: 56px;
+}
+
+.header--left {
+  position: absolute;
+  left: 20px;
+}
+
+.header--center--title {
+  font-size: 16px;
+  font-weight: 400;
+}

--- a/frontend/public/css/common/global_color.css
+++ b/frontend/public/css/common/global_color.css
@@ -1,0 +1,5 @@
+:root {
+  --header-bg-color: #f6f6f6;
+  --input-border-color: #d7d7d7;
+  --primary1-color: #2ac1bc;
+}

--- a/frontend/public/css/login.css
+++ b/frontend/public/css/login.css
@@ -1,33 +1,11 @@
-:root {
-  --header-bg-color: #f6f6f6;
-  --input-border-color: #d7d7d7;
-  --primary1-color: #2ac1bc;
-}
+@import url("./common/basic_header.css");
+@import url("./common/global_color.css");
 
 body {
   padding: 0px;
   border: 1px solid #c0c0c0;
   display: flex;
   flex-direction: column;
-}
-
-.login-header {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background-color: var(--header-bg-color);
-  border-bottom: 1px solid #c0c0c0;
-  height: 56px;
-}
-
-.login-header--left {
-  position: absolute;
-  left: 20px;
-}
-
-.login-header--center--title {
-  font-size: 16px;
-  font-weight: 400;
 }
 
 .login-main {

--- a/frontend/public/css/profile.css
+++ b/frontend/public/css/profile.css
@@ -1,33 +1,11 @@
-:root {
-  --header-bg-color: #f6f6f6;
-  --input-border-color: #d7d7d7;
-  --primary1-color: #2ac1bc;
-}
+@import url("./common/basic_header.css");
+@import url("./common/global_color.css");
 
 body {
   padding: 0px;
   border: 1px solid #c0c0c0;
   display: flex;
   flex-direction: column;
-}
-
-.login-header {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background-color: var(--header-bg-color);
-  border-bottom: 1px solid #c0c0c0;
-  height: 56px;
-}
-
-.login-header--left {
-  position: absolute;
-  left: 20px;
-}
-
-.login-header--center--title {
-  font-size: 16px;
-  font-weight: 400;
 }
 
 .profile-main {

--- a/frontend/public/css/signup.css
+++ b/frontend/public/css/signup.css
@@ -1,33 +1,11 @@
-:root {
-  --header-bg-color: #f6f6f6;
-  --input-border-color: #d7d7d7;
-  --primary1-color: #2ac1bc;
-}
+@import url("./common/basic_header.css");
+@import url("./common/global_color.css");
 
 body {
   padding: 0px;
   display: flex;
   flex-direction: column;
   border: 1px solid #c0c0c0;
-}
-
-.login-header {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background-color: var(--header-bg-color);
-  border-bottom: 1px solid #c0c0c0;
-  height: 56px;
-}
-
-.login-header--left {
-  position: absolute;
-  left: 20px;
-}
-
-.login-header--center--title {
-  font-size: 16px;
-  font-weight: 400;
 }
 
 .signup-main {

--- a/frontend/public/login.html
+++ b/frontend/public/login.html
@@ -10,12 +10,12 @@
     <title>로그인</title>
   </head>
   <body>
-    <header class="login-header">
-      <a class="login-header--left" href="./main.html">
+    <header class="header">
+      <a class="header--left" href="./main.html">
         <img src="./icon/chevron-left.svg" />
       </a>
-      <h1 class="login-header--center">
-        <span class="login-header--center--title"> 로그인 </span>
+      <h1 class="header--center">
+        <span class="header--center--title"> 로그인 </span>
       </h1>
     </header>
     <main class="login-main">

--- a/frontend/public/profile.html
+++ b/frontend/public/profile.html
@@ -9,12 +9,12 @@
     <title>내 계정</title>
   </head>
   <body>
-    <header class="login-header">
-      <a class="login-header--left" href="./login.html">
+    <header class="header">
+      <a class="header--left" href="./login.html">
         <img src="./icon/chevron-left.svg" />
       </a>
-      <h1 class="login-header--center">
-        <span class="login-header--center--title"> 내 계정 </span>
+      <h1 class="header--center">
+        <span class="header--center--title"> 내 계정 </span>
       </h1>
     </header>
     <main class="profile-main">

--- a/frontend/public/signup.html
+++ b/frontend/public/signup.html
@@ -10,12 +10,12 @@
     <title>회원가입</title>
   </head>
   <body>
-    <header class="login-header">
-      <a class="login-header--left" href="./login.html">
+    <header class="header">
+      <a class="header--left" href="./login.html">
         <img src="./icon/chevron-left.svg" />
       </a>
-      <h1 class="login-header--center">
-        <span class="login-header--center--title"> 회원가입 </span>
+      <h1 class="header--center">
+        <span class="header--center--title"> 회원가입 </span>
       </h1>
     </header>
     <main class="signup-main">


### PR DESCRIPTION
관련 이슈 : #6 

## 개요

카테고리 UI를 기획서와 디자인 문서에 맞게 Markup 작업을 진행한 PR 입니다. 

## 변경사항

기존 login, signup, profile 에서 사용된 header의 스타일이 동일한 방식이어서 `common/basic_header.css`파일에  따로 생성해놨습니다. 

다른 파일에서는 아래와 같이 사용했습니다.
```
@import url("./common/basic_header.css")
```

color 변수로 전역변수로 `global_color.css`로 추가해놨습니다. 방식은 위와 동일합니다.

## 참고사항

## 추가 구현 필요사항

## 스크린샷

<img width="499" alt="스크린샷 2021-07-13 오후 6 29 49" src="https://user-images.githubusercontent.com/20085849/125428265-8e7b4183-3ba9-46f3-874d-4b01b1ba4b77.png">

