### PR TITLE
[Markup] 글쓰기 레이아웃과 스타일링

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -8,6 +8,9 @@
 .AppleDouble
 .LSOverride
 
+# Icon must end with two \r
+# Icon
+
 
 # Thumbnails
 ._*

--- a/frontend/public/category.html
+++ b/frontend/public/category.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="/css/normalize.css" />
     <link rel="stylesheet" href="/css/category.css" />
 
-    <title>로그인</title>
+    <title>카테고리</title>
   </head>
   <body>
     <header class="header">

--- a/frontend/public/createPost.html
+++ b/frontend/public/createPost.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/css/normalize.css" />
+    <link rel="stylesheet" href="/css/createPost.css" />
+    <title>글쓰기</title>
+  </head>
+  <body>
+    <header class="header">
+      <a class="header--left" href="./main.html">
+        <img src="./icon/chevron-left.svg" />
+      </a>
+      <h1 class="header--center">
+        <span class="header--center--title"> 글쓰기 </span>
+      </h1>
+      <div class="header-right">
+        <img src="./icon/check.svg" />
+      </div>
+    </header>
+    <main class="posting-main">
+      <div class="posting-main--img-register">
+        <img
+          class="posting-main--img-register--img"
+          src="./icon/image.svg"
+          height="24"
+          width="24"
+        />
+        <p class="posting-main--img-register--msg">
+          <span>0</span>/<span>10</span>
+        </p>
+      </div>
+      <span class="split-line"></span>
+
+      <input
+        class="posting-main--text-input"
+        type="text"
+        placeholder="글 제목"
+      />
+      <span class="split-line"></span>
+
+      <input
+        class="posting-main--text-input"
+        type="text"
+        placeholder="가격 (선택사항)"
+      />
+      <span class="split-line"></span>
+
+      <span
+        class="posting-main--textarea expand-textarea"
+        role="textbox"
+        contenteditable
+      ></span>
+    </main>
+    <footer>
+      <img src="icon/map-pin.svg" />
+      <p class="footer-text">상암동</p>
+    </footer>
+  </body>
+</html>

--- a/frontend/public/createPost.html
+++ b/frontend/public/createPost.html
@@ -39,11 +39,33 @@
         type="text"
         placeholder="글 제목"
       />
+
+      <input
+        class="posting-main--text-input subtext"
+        type="text"
+        placeholder="(필수) 카테고리를 선택해주세요."
+      />
+
+      <div class="posting-main-tag-container">
+        <span class="tag"
+          >여성 패션/합화
+          <span class="close-btn"> <img src="./icon/close-white.svg" /></span
+        ></span>
+        <span class="tag"
+          >Test<span class="close-btn">
+            <img src="./icon/close-white.svg" /></span
+        ></span>
+        <span class="tag"
+          >여성 패션/합화
+          <span class="close-btn"> <img src="./icon/close-white.svg" /></span
+        ></span>
+      </div>
+
       <span class="split-line"></span>
 
       <input
         class="posting-main--text-input"
-        type="text"
+        type="number"
         placeholder="가격 (선택사항)"
       />
       <span class="split-line"></span>

--- a/frontend/public/createPost.html
+++ b/frontend/public/createPost.html
@@ -16,7 +16,7 @@
       <h1 class="header--center">
         <span class="header--center--title"> 글쓰기 </span>
       </h1>
-      <a class="header-right" href="./main.html">
+      <a class="header--right" href="./main.html">
         <img src="./icon/check.svg" />
       </a>
     </header>

--- a/frontend/public/createPost.html
+++ b/frontend/public/createPost.html
@@ -16,9 +16,9 @@
       <h1 class="header--center">
         <span class="header--center--title"> 글쓰기 </span>
       </h1>
-      <div class="header-right">
+      <a class="header-right" href="./main.html">
         <img src="./icon/check.svg" />
-      </div>
+      </a>
     </header>
     <main class="posting-main">
       <div class="posting-main--img-register">

--- a/frontend/public/css/common/basic_header.css
+++ b/frontend/public/css/common/basic_header.css
@@ -16,3 +16,8 @@
   font-size: 16px;
   font-weight: 400;
 }
+
+.header-right {
+  position: absolute;
+  right: 20px;
+}

--- a/frontend/public/css/common/basic_header.css
+++ b/frontend/public/css/common/basic_header.css
@@ -17,7 +17,7 @@
   font-weight: 400;
 }
 
-.header-right {
+.header--right {
   position: absolute;
   right: 20px;
 }

--- a/frontend/public/css/createPost.css
+++ b/frontend/public/css/createPost.css
@@ -1,0 +1,71 @@
+@import url("./common/basic_header.css");
+@import url("./common/global_color.css");
+
+.posting-main {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  background-color: white;
+  flex-grow: 1;
+  padding-left: 15px;
+  padding-right: 15px;
+}
+
+.posting-main--img-register {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 76px;
+  height: 76px;
+  background-color: #f6f6f6;
+  border-radius: 8px;
+  margin-top: 24px;
+}
+
+.posting-main--img-register--img {
+  margin: 5px;
+}
+
+.posting-main--img-register--msg {
+  font-size: 12px;
+  font-weight: 400;
+  text-align: center;
+}
+
+.posting-main--text-input {
+  border: none;
+}
+
+.posting-main--textarea {
+  display: block;
+  border: none;
+  overflow: scroll;
+  resize: none;
+  min-height: 40px;
+  max-height: 160px;
+  line-height: 20px;
+}
+
+.expand-textarea[contenteditable]:empty::before {
+  content: "게시글 내용을 작성해주세요.";
+  color: gray;
+}
+
+.split-line {
+  width: 100%;
+  height: 1px;
+  margin-top: 24px;
+  margin-bottom: 24px;
+  border: 0.5px solid #c0c0c0;
+}
+
+footer {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 12px;
+  display: flex;
+  align-items: center;
+  background-color: white;
+  border-top: 1px solid #c0c0c0;
+}

--- a/frontend/public/css/createPost.css
+++ b/frontend/public/css/createPost.css
@@ -1,6 +1,10 @@
 @import url("./common/basic_header.css");
 @import url("./common/global_color.css");
 
+body {
+  border: 1px solid #c0c0c0;
+}
+
 .posting-main {
   display: flex;
   flex-direction: column;

--- a/frontend/public/css/createPost.css
+++ b/frontend/public/css/createPost.css
@@ -13,6 +13,7 @@ body {
   flex-grow: 1;
   padding-left: 15px;
   padding-right: 15px;
+  overflow: scroll;
 }
 
 .posting-main--img-register {
@@ -38,7 +39,57 @@ body {
 }
 
 .posting-main--text-input {
+  font-size: 16px;
+  font-weight: 400;
   border: none;
+}
+
+.posting-main--text-input:focus {
+  outline: none;
+}
+
+.posting-main--text-input.subtext {
+  margin-top: 16px;
+  margin-bottom: 16px;
+  font-size: 14px;
+}
+
+.posting-main-tag-container {
+  display: flex;
+  overflow-y: visible;
+}
+
+.posting-main-tag-container .tag {
+  font-size: 16px;
+  font-weight: 400;
+  margin-right: 2px;
+  color: #888888;
+  padding: 5px 8px;
+  border: 1px solid #c0c0c0;
+  border-radius: 16px;
+  vertical-align: middle;
+  position: relative;
+  overflow: visible;
+}
+
+.close-btn {
+  display: none;
+}
+
+.close-btn img {
+  width: 15px;
+  height: 15px;
+}
+
+.tag:hover .close-btn {
+  display: block;
+  position: absolute;
+  right: -5px;
+  top: -5px;
+  background-color: var(--primary1-color);
+  color: white;
+  height: 15px;
+  border-radius: 8px;
 }
 
 .posting-main--textarea {
@@ -49,6 +100,8 @@ body {
   min-height: 40px;
   max-height: 160px;
   line-height: 20px;
+  font-size: 16px;
+  font-weight: 400;
 }
 
 .expand-textarea[contenteditable]:empty::before {

--- a/frontend/public/icon/check.svg
+++ b/frontend/public/icon/check.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="14" viewBox="0 0 20 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19 1L6.625 13L1 7.54545" stroke="#111111" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/public/icon/chevron-left.svg
+++ b/frontend/public/icon/chevron-left.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="18" viewBox="0 0 10 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 17L1 9L9 1" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/public/icon/close-white.svg
+++ b/frontend/public/icon/close-white.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 6L6 18" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 6L18 18" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/public/icon/close.svg
+++ b/frontend/public/icon/close.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 6L6 18" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 6L18 18" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/public/icon/image.svg
+++ b/frontend/public/icon/image.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19 3H5C3.89543 3 3 3.89543 3 5V19C3 20.1046 3.89543 21 5 21H19C20.1046 21 21 20.1046 21 19V5C21 3.89543 20.1046 3 19 3Z" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.5 10C9.32843 10 10 9.32843 10 8.5C10 7.67157 9.32843 7 8.5 7C7.67157 7 7 7.67157 7 8.5C7 9.32843 7.67157 10 8.5 10Z" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 15L16 10L5 21" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/public/icon/map-pin.svg
+++ b/frontend/public/icon/map-pin.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M21 10C21 17 12 23 12 23C12 23 3 17 3 10C3 7.61305 3.94821 5.32387 5.63604 3.63604C7.32387 1.94821 9.61305 1 12 1C14.3869 1 16.6761 1.94821 18.364 3.63604C20.0518 5.32387 21 7.61305 21 10Z" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 13C13.6569 13 15 11.6569 15 10C15 8.34315 13.6569 7 12 7C10.3431 7 9 8.34315 9 10C9 11.6569 10.3431 13 12 13Z" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
관련 이슈: #8 

## 개요

글쓰기 레이아웃, 스타일 작업과 관련된 PR 입니다.
 
## 변경사항

글내용을 textarea가 아닌 span을 활용해서 자동으로 사용자 입력에의해 확장,축소되는 형태로 만들었습니다.

그외에는 특별한 내용은 없습니다.

## 참고사항
## 추가 구현 필요사항
## 스크린샷

<img width="343" alt="스크린샷 2021-07-13 오후 7 51 25" src="https://user-images.githubusercontent.com/20085849/125439776-d31c9fc4-0448-4a89-8e6a-b4728b291187.png">

- 카테고리 입력창 활성화 

<img width="524" alt="스크린샷 2021-07-13 오후 8 45 23" src="https://user-images.githubusercontent.com/20085849/125446279-0aaeeddd-935a-4230-b26b-b8aff75901f5.png">
