### PR TITLE
[Markup] 채팅 상세 페이지 레이아웃과 스타일 #11

### DIFF
--- a/frontend/public/chat.html
+++ b/frontend/public/chat.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/css/normalize.css" />
+    <link rel="stylesheet" href="/css/chat.css" />
+
+    <title>채팅</title>
+  </head>
+  <body>
+    <header class="header">
+      <a class="header--left" href="./main.html">
+        <img src="./icon/chevron-left.svg" />
+      </a>
+      <h1 class="header--center">
+        <span class="header--center--title"> UserE </span>
+      </h1>
+      <a class="header--right" href="#">
+        <img src="./icon/log-out.svg" />
+      </a>
+    </header>
+    <main class="chat-main">
+      <div class="chat-main--header">
+        <img class="chat-main--header--img" src="./image/example-skate.svg" />
+        <div class="chat-main--header--content">
+          <p>빈티지 롤러 스케이트</p>
+          <p>160,000원</p>
+        </div>
+        <div class="chat-main--header--status">판매중</div>
+      </div>
+      <div class="chat-main--content">
+        <div class="chat-main--content--message">
+          안녕하세요! 궁금한게 있는데요
+        </div>
+        <div class="chat-main--content--message my">네 안녕하세요!</div>
+        <div class="chat-main--content--message">혹시</div>
+        <div class="chat-main--content--message">
+          실제로 신어볼 수 있는 건가요?
+        </div>
+        <div class="chat-main--content--message">
+          실제로 신어볼 수 있는 건가요?
+        </div>
+        <div class="chat-main--content--message">
+          실제로 신어볼 수 있는 건가요?
+        </div>
+        <div class="chat-main--content--message">
+          실제로 신어볼 수 있는 건가요?
+        </div>
+      </div>
+      <div class="chat-main--input-container">
+        <input class="chat-main--input-container--input" type="text" />
+        <img
+          class="chat-main--input-container--submit-btn"
+          src="./icon/send.svg"
+        />
+      </div>
+    </main>
+  </body>
+</html>

--- a/frontend/public/chat.html
+++ b/frontend/public/chat.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/css/normalize.css" />
     <link rel="stylesheet" href="/css/chat.css" />
-
+    <script defer src="./js/chat.js"></script>
     <title>채팅</title>
   </head>
   <body>
@@ -17,9 +17,9 @@
       <h1 class="header--center">
         <span class="header--center--title"> UserE </span>
       </h1>
-      <a class="header--right" href="#">
+      <div id="out-btn" class="header--right" href="#">
         <img src="./icon/log-out.svg" />
-      </a>
+      </div>
     </header>
     <main class="chat-main">
       <div class="chat-main--header">
@@ -57,5 +57,17 @@
         />
       </div>
     </main>
+    <!-- Modal -->
+    <div id="alert-modal" class="alert-modal">
+      <p>정말로이 채팅방을 나가시겠습니까?</p>
+      <div class="alert-modal--btn-container">
+        <div id="cancel-btn" class="alert-modal--btn-container--cancel-btn">
+          취소
+        </div>
+        <div id="accept-btn" class="alert-modal--btn-container--accept-btn">
+          나가기
+        </div>
+      </div>
+    </div>
   </body>
 </html>

--- a/frontend/public/css/chat.css
+++ b/frontend/public/css/chat.css
@@ -103,3 +103,44 @@ body {
   width: 24px;
   height: 24px;
 }
+
+.supreme-container {
+  display: block;
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 568px;
+  background-color: red;
+}
+
+.alert-modal {
+  /* visibility: hidden; */
+  visibility: visible;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 288px;
+  height: 88px;
+  border-radius: 8px;
+  background-color: #f6f6f6;
+  box-shadow: 0px 0px 4px rgba(204, 204, 204, 0.5),
+    0px 2px 4px rgba(0, 0, 0, 0.25);
+}
+.alert-modal--btn-container {
+  margin-top: 16px;
+  display: flex;
+  justify-content: space-between;
+}
+.alert-modal--btn-container--accept-btn {
+  color: red;
+}
+
+.alert-modal--btn-container--accept-btn:hover {
+  color: red;
+}

--- a/frontend/public/css/chat.css
+++ b/frontend/public/css/chat.css
@@ -1,0 +1,105 @@
+@import url("./common/basic_header.css");
+@import url("./common/global_color.css");
+
+body {
+  border: 1px solid #c0c0c0;
+}
+
+.chat-main {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background-color: white;
+}
+
+.chat-main--header {
+  display: flex;
+  border-bottom: 1px solid #d7d7d7;
+  height: 72px;
+  padding: 16px;
+}
+
+.chat-main--header--img {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  border: 1px solid #e0e0e0;
+}
+.chat-main--header--content {
+  flex-grow: 1;
+  margin-left: 8px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.chat-main--content {
+  display: flex;
+  flex-direction: column;
+  padding: 15px 16px;
+  height: 267px;
+  overflow: scroll;
+}
+
+.chat-main--content--message {
+  font-size: 14px;
+  padding: 8px;
+  justify-self: flex-start;
+  border-radius: 0px 8px 8px 8px;
+  border: 1px solid var(--primary1-color);
+  max-width: 195px;
+}
+
+.chat-main--content--message:not(:last-child) {
+  margin-bottom: 24px;
+}
+
+.chat-main--content--message.my {
+  align-self: flex-end;
+  border-radius: 8px 0px 8px 8px;
+  background-color: var(--primary1-color);
+  color: white;
+}
+
+.chat-main--header--status {
+  width: 71px;
+  height: 40px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.chat-main--content {
+  flex-grow: 1;
+}
+
+.chat-main--input-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #f6f6f6;
+  border-top: 1px solid #d7d7d7;
+  width: 100%;
+  height: 68px;
+  bottom: 0px;
+}
+
+.chat-main--input-container--input {
+  width: 256px;
+  height: 36px;
+  border: 1px solid #d7d7d7;
+  border-radius: 8px;
+  margin: 0px;
+}
+
+.chat-main--input-container--input:focus {
+  outline: none;
+  border: 1px solid var(--primary1-color);
+}
+
+.chat-main--input-container--submit-btn {
+  width: 24px;
+  height: 24px;
+}

--- a/frontend/public/icon/log-out.svg
+++ b/frontend/public/icon/log-out.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V5C3 4.46957 3.21071 3.96086 3.58579 3.58579C3.96086 3.21071 4.46957 3 5 3H9" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16 17L21 12L16 7" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 12H9" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/public/icon/send.svg
+++ b/frontend/public/icon/send.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M22 2L11 13" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M22 2L15 22L11 13L2 9L22 2Z" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/public/js/chat.js
+++ b/frontend/public/js/chat.js
@@ -1,0 +1,39 @@
+function hideModal() {
+  const $modal = document.querySelector("#alert-modal");
+  $modal.style.visibility = "hidden";
+}
+
+function showModal() {
+  const $modal = document.querySelector("#alert-modal");
+  $modal.style.visibility = "visible";
+}
+
+function chatOutClickEventBinding() {
+  const $outBtn = document.querySelector("#out-btn");
+
+  $outBtn.addEventListener("click", () => {
+    showModal();
+  });
+}
+
+function modalEventsBinding() {
+  const $cancelBtn = document.querySelector("#cancel-btn");
+  const $acceptBtn = document.querySelector("#accept-btn");
+
+  $cancelBtn.addEventListener("click", () => {
+    hideModal();
+  });
+  $acceptBtn.addEventListener("click", () => {
+    // TODO: Navigate
+    hideModal();
+  });
+}
+
+function eventsBinding() {
+  chatOutClickEventBinding();
+  modalEventsBinding();
+}
+
+window.addEventListener("DOMContentLoaded", () => {
+  eventsBinding();
+});


### PR DESCRIPTION
#11 

## 개요

채팅 상세 페이지 레이아웃관련 작업에 대한 PR 입니다. 

Chat Message들을 스크롤해서 볼 수는 있지만 동적으로 추가되는 기능은 아직 구현하지 못했습니다.
SPA구조로 프로젝트를 변환할 때 자바스크립트를 사용해서 반영할 예정입니다. 

## 변경사항

모달 스타일을 추가 했습니다. 
다른 페이지에서 스타일을 재사용할 필요가 있습니다.

## 참고사항

뒷배경이 blur처리를 해야할지 정해져있지않아서 우선 추가하지는 않았습니다.

## 추가 구현 필요사항

- 채팅에 의한 자동 스크롤 다운
- 모달 뒷배경 blur 처리(css filter 활용하면 될 것)

## 스크린샷
<img width="399" alt="스크린샷 2021-07-14 오후 5 21 32" src="https://user-images.githubusercontent.com/20085849/125590192-8dfd3c5e-b87c-48d6-bf0e-bfb5c9d8d826.png">

