### PR TITLE
[MarkUp] 상품상세에서 들어가는 채팅목록 페이지

### DIFF
--- a/frontend/public/chatList.html
+++ b/frontend/public/chatList.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/css/normalize.css" />
+    <link rel="stylesheet" href="/css/chatList.css" />
+    <title>채팅</title>
+  </head>
+  <body>
+    <header class="header">
+      <a class="header--left" href="./detailPost.html">
+        <img src="./icon/chevron-left.svg" />
+      </a>
+      <h1 class="header--center">
+        <span class="header--center--title"> 채팅하기 </span>
+      </h1>
+    </header>
+    <div class="content">
+      <article class="content--chat-item unread">
+        <div class="content--chat-item--left">
+          <strong class="username">UserC</strong>
+          <span class="current-message">혹시 팔렸나요?</span>
+        </div>
+        <div class="content--chat-item--right">
+          <div class="content--chat-item--right--left">
+            <div><span class="current-chat-time">15분전</span></div>
+            <div><div class="un-read-count">1</div></div>
+          </div>
+          <a class="content--chat-item--right--right">
+            <img src="/image/example-cooler.svg" alt="상품 썸네일 사진" />
+          </a>
+        </div>
+      </article>
+      <article class="content--chat-item unread">
+        <div class="content--chat-item--left">
+          <strong class="username">UserC</strong>
+          <span class="current-message">혹시 팔렸나요?</span>
+        </div>
+        <div class="content--chat-item--right">
+          <div class="content--chat-item--right--left">
+            <div><span class="current-chat-time">15분전</span></div>
+            <div><div class="un-read-count">1</div></div>
+          </div>
+          <a class="content--chat-item--right--right">
+            <img src="/image/example-cooler.svg" alt="상품 썸네일 사진" />
+          </a>
+        </div>
+      </article>
+      <article class="content--chat-item">
+        <div class="content--chat-item--left">
+          <strong class="username">UserC</strong>
+          <span class="current-message">혹시 팔렸나요?</span>
+        </div>
+        <div class="content--chat-item--right">
+          <div class="content--chat-item--right--left">
+            <div><span class="current-chat-time">15분전</span></div>
+            <div></div>
+          </div>
+          <a class="content--chat-item--right--right">
+            <img src="/image/example-cooler.svg" alt="상품 썸네일 사진" />
+          </a>
+        </div>
+      </article>
+    </div>
+  </body>
+</html>

--- a/frontend/public/css/chatList.css
+++ b/frontend/public/css/chatList.css
@@ -1,0 +1,19 @@
+@import url('./common/basic_header.css');
+@import url('./common/chat_list_item.css');
+body {
+  background-color: #fff;
+}
+
+.header {
+  background-color: #fff;
+}
+
+.content {
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-start;
+  flex-direction: column;
+  flex: 1;
+  overflow-y: scroll;
+  height: 100%;
+}


### PR DESCRIPTION
#7 <img width="498" alt="스크린샷 2021-07-15 오전 10 06 05" src="https://user-images.githubusercontent.com/47034129/125711929-23b0afb2-3510-4650-9d27-74f9fbbc25ca.png">
## 개요
- 상품상세페이지에서 들어가는 채팅 목록 페이지

## 변경사항
- chatList.html
- chatLIst.css
 
## 참고사항
- basic header을 적용한 뒤 색깔을 바꿈
- menu에서 사용한것과 같은 chat item 사용


## 스크린샷
<img width="424" alt="스크린샷 2021-07-15 오전 10 06 52" src="https://user-images.githubusercontent.com/47034129/125711980-1e0fabf2-6316-4937-a950-adb4c0821168.png">
