### PR TITLE
[BE] 로그인, 로그아웃, 회원가입, 프로필 관련 API  프론트엔드에 반영 

### DIFF
--- a/backend/src/routes/api/auth/index.js
+++ b/backend/src/routes/api/auth/index.js
@@ -4,7 +4,7 @@ const accountStore = new AccountStore();
 
 const router = express.Router();
 
-const ERROR_MSG_DUPLICATE = "Duplicate username";
+const ERROR_MSG_DUPLICATE = "중복된 아이디가 존재합니다.";
 
 router.post("/signin", async (req, res) => {
   const { username } = req.body;

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -13,18 +13,30 @@ export const loginAsync = ({ id }) =>
     resolve(request);
   });
 
-export const signupAsync = ({ id, location }, cb) =>
+export const signupAsync = ({ id, location }) =>
   new Promise((resolve, reject) => {
-    setTimeout(() => {
-      console.log(`Signup Request with id: ${id}, location:${location}`);
-      cb();
-    }, 500);
+    const request = fetch("/api/auth/signup", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        username: id,
+        location: location,
+      }),
+    }).then((response) => response.json());
+
+    resolve(request);
   });
 
-export const logoutAsync = (cb) =>
+export const logoutAsync = () =>
   new Promise((resolve, reject) => {
-    setTimeout(() => {
-      console.log(`Logout`);
-      cb();
-    }, 500);
+    const request = fetch("/api/auth/signout", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }).then((response) => response.json());
+
+    resolve(request);
   });

--- a/frontend/src/api/user.js
+++ b/frontend/src/api/user.js
@@ -1,11 +1,13 @@
 export const getProfileAsync = () =>
   new Promise((resolve, reject) => {
-    setTimeout(() => {
-      resolve({
-        username: "Woowahan",
-        locations: ["역삼동"],
-      });
-    }, 500);
+    const request = fetch("/api/account/me", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }).then((response) => response.json());
+
+    resolve(request);
   });
 
 export const addLocationAsync = (location) => {

--- a/frontend/src/page/HomePage/Controller.js
+++ b/frontend/src/page/HomePage/Controller.js
@@ -68,7 +68,8 @@ export default class Controller {
           this.store.products = products;
           this.render();
         } else {
-          navigateTo("/login");
+          this.store.products = products;
+          this.render();
         }
       }
     );

--- a/frontend/src/page/HomePage/Controller.js
+++ b/frontend/src/page/HomePage/Controller.js
@@ -2,6 +2,7 @@ const tag = "[HomePage Controller]";
 
 import { getAllProductsAsync, getProducts } from "@/api/product";
 import { getProfileAsync } from "@/api/user";
+import { navigateTo } from "@/router";
 
 export default class Controller {
   constructor(
@@ -55,17 +56,20 @@ export default class Controller {
     const requestProducts = getAllProductsAsync();
     const requestUserProfile = getProfileAsync();
     Promise.all([requestProducts, requestUserProfile]).then(
-      ([products, user]) => {
-        if (!user) {
+      ([products, { isAuth, account }]) => {
+        if (isAuth) {
+          this.store.user = account;
+          if (this.store.currentLocation === "") {
+            this.store.currentLocation =
+              this.store.user.locations.length > 0
+                ? this.store.user.locations[0]
+                : "";
+          }
+          this.store.products = products;
+          this.render();
+        } else {
           navigateTo("/login");
         }
-        this.store.user = user;
-        if (this.store.currentLocation === "") {
-          this.store.currentLocation =
-            user.locations.length > 0 ? user.locations[0] : "";
-        }
-        this.store.products = products;
-        this.render();
       }
     );
   }

--- a/frontend/src/page/LoginPage/Controller.js
+++ b/frontend/src/page/LoginPage/Controller.js
@@ -1,4 +1,5 @@
 import { loginAsync } from "@/api/auth";
+import { getProfileAsync } from "@/api/user";
 import { navigateTo } from "@/router";
 
 const ERROR_USERNAME_INVALID = "존재하지않는 사용자입니다.";
@@ -9,9 +10,17 @@ export default class Controller {
     console.log(tag);
     this.loginFormView = loginFormView;
 
+    this.init();
     this.error = {};
     this.subscribeViewEvents();
     this.render();
+  }
+  init() {
+    getProfileAsync().then(({ account, isAuth }) => {
+      if (isAuth) {
+        navigateTo("/profile");
+      }
+    });
   }
 
   subscribeViewEvents() {

--- a/frontend/src/page/ProfilePage/Controller.js
+++ b/frontend/src/page/ProfilePage/Controller.js
@@ -15,9 +15,12 @@ export default class Controller {
 
   init() {
     // Get Username from server
-    getProfileAsync().then((data) => {
-      const { username } = data;
-      this.render(username);
+    getProfileAsync().then(({ isAuth, account }) => {
+      if (!isAuth) {
+        navigateTo("/login");
+      } else {
+        this.render(account.username);
+      }
     });
   }
 
@@ -27,8 +30,11 @@ export default class Controller {
 
   logout() {
     // TODO: start spinner
-    logoutAsync(() => {
-      navigateTo("/login");
+    logoutAsync().then((result) => {
+      console.log(result);
+      if (result.success) {
+        navigateTo("/");
+      }
     });
   }
 

--- a/frontend/src/page/ProfilePage/index.js
+++ b/frontend/src/page/ProfilePage/index.js
@@ -18,7 +18,7 @@ export default class ProfilePage extends AbstractPage {
   async render() {
     return /*html*/ ` 
     <header class="header">
-        <a class="header--left" href="/login" data-link>
+        <a class="header--left" href="/" data-link>
         <div class="back-icon">${chevronLeftSVG}</div>
         </a>
         <h1 class="header--center">

--- a/frontend/src/page/SignupPage/Controller.js
+++ b/frontend/src/page/SignupPage/Controller.js
@@ -1,11 +1,14 @@
 import { signupAsync } from "@/api/auth";
 import { navigateTo } from "@/router";
 
-const tag = "[Signup Controller]";
+const ERROR_LOCATION_EMPTY = "우리 동네를 필수로 입력해야합니다.";
+const ERROR_USERNAME_EMPTY = "아이디를 필수로 입력해야합니다.";
+
 export default class Controller {
   constructor({ signupFormView }) {
     this.signupFormView = signupFormView;
     this.subscribeViewEvents();
+    this.error = {};
     this.render();
   }
 
@@ -14,18 +17,30 @@ export default class Controller {
   }
 
   signup({ id, location }) {
-    signupAsync(
-      {
+    if (!id || id === "") {
+      this.error = { username: ERROR_USERNAME_EMPTY };
+      this.render();
+    } else if (!location || location === "") {
+      this.error = { location: ERROR_LOCATION_EMPTY };
+      this.render();
+    } else {
+      signupAsync({
         id,
         location,
-      },
-      () => {
-        navigateTo("/profile");
-      }
-    );
+      }).then(({ success, error }) => {
+        if (success) {
+          navigateTo("/profile");
+        } else {
+          this.error = {
+            username: error,
+          };
+          this.render();
+        }
+      });
+    }
   }
 
   render() {
-    this.signupFormView.show();
+    this.signupFormView.show(this.error);
   }
 }

--- a/frontend/src/page/SignupPage/index.js
+++ b/frontend/src/page/SignupPage/index.js
@@ -31,6 +31,7 @@ export default class LoginPage extends AbstractPage {
         type="text"
         placeholder="문자, 숫자 조합 20자 이상"
       />
+      <div id="id-error-message" class="error-message"></div>
       <label for="location-input" class="signup-main--label">우리 동네</label>
       <input
         id="location-input"
@@ -38,6 +39,8 @@ export default class LoginPage extends AbstractPage {
         type="text"
         placeholder="시-구 제외, 동만 입력"
       />
+      <div id="location-error-message" class="error-message"></div>
+
       <div id="signup-btn" class="signup-main--submit-btn">회원가입</div>
     </main>
     `;

--- a/frontend/src/page/SignupPage/views/SignupFormView.js
+++ b/frontend/src/page/SignupPage/views/SignupFormView.js
@@ -10,7 +10,12 @@ export default class SignupFormView extends View {
     super(element);
 
     this.idInputElement = qs("#id-input", this.element);
+    this.idErrorMessageElement = qs("#id-error-message", this.element);
     this.locationInputElement = qs("#location-input", this.element);
+    this.locationErrorMessageElement = qs(
+      "#location-error-message",
+      this.element
+    );
     this.submitButtonElement = qs("#signup-btn", this.element);
     this.bindingEvents();
   }
@@ -30,7 +35,17 @@ export default class SignupFormView extends View {
     });
   }
 
-  show() {
+  show(error = {}) {
+    if (error["username"]) {
+      this.idErrorMessageElement.innerText = error["username"];
+    } else {
+      this.idErrorMessageElement.innerText = "";
+    }
+    if (error["location"]) {
+      this.locationErrorMessageElement.innerText = error["location"];
+    } else {
+      this.locationErrorMessageElement.innerText = "";
+    }
     super.show();
   }
 }


### PR DESCRIPTION
#25 

## 개요

로그인, 로그아웃, 회원가입, 프로필 화면에 만들어진 API를 적용해서 기능 구현을 완료했습니다.

해당 작업 중 각 입력 값을 검증하는 코드도 추가했습니다.

화면마다 로그인이 되어있는지 여부는 `/api/account/me` 속 isAuth값이 true인지 체크해서 처리해야할 것 같습니다. (메인 화면이나 로그인화면으로 네비게이션하면 될 듯합니다.)

## 변경사항

(Mock API를 실제 fetch API로 변경했기 때문에 개요의 내용으로 대체합니다.)

## 참고사항
## 추가 구현 필요사항
## 스크린샷

<img width="356" alt="스크린샷 2021-07-18 오후 7 36 11" src="https://user-images.githubusercontent.com/20085849/126064385-94df35d2-934a-47f9-ad3e-f59d45478b1a.png">
<img width="372" alt="스크린샷 2021-07-18 오후 7 36 24" src="https://user-images.githubusercontent.com/20085849/126064389-c7cc884f-ba14-49b8-8e95-f1270c7cbbca.png">
<img width="362" alt="스크린샷 2021-07-18 오후 7 36 43" src="https://user-images.githubusercontent.com/20085849/126064392-0f8ab420-5147-43f2-959b-49a24745d07a.png">


