### PR TITLE
[Backend] account api MysqlAccountStore로 accountStore 변경 및 auth api 리팩토링

### DIFF
--- a/backend/src/model/Account/Store/MySQLAccountStore.js
+++ b/backend/src/model/Account/Store/MySQLAccountStore.js
@@ -69,5 +69,18 @@ export default class MySQLAccountStore extends AbstractAccountStore {
       return null;
     }
   }
-  async removeLocation(username, location) {}
+  async removeLocation(username, location) {
+    const query = "DELETE from location WHERE username=? AND location=?;";
+    const params = [username, location];
+    try {
+      const result = await mysqlConnection.promise().query(query, params);
+      const deleteResult = result[0]?.affectedRows === 1;
+      if (deleteResult) {
+        return true;
+      }
+      return false;
+    } catch (err) {
+      return false;
+    }
+  }
 }

--- a/backend/src/model/Account/Store/MySQLAccountStore.js
+++ b/backend/src/model/Account/Store/MySQLAccountStore.js
@@ -34,14 +34,18 @@ export default class MySQLAccountStore extends AbstractAccountStore {
     `;
     const params2 = [username, location];
     try {
+      // TODO result 문서 확인 후 변경
       const accountResult = await mysqlConnection
         .promise()
         .query(query1, params1);
-      if (accountResult) {
+      const isAddedAccountRow = accountResult[0]?.affectedRows === 1;
+      if (isAddedAccountRow) {
         const locationResult = await mysqlConnection
           .promise()
           .query(query2, params2);
-        if (locationResult) {
+
+        const isAddedLocationRow = locationResult[0]?.affectedRows === 1;
+        if (isAddedLocationRow) {
           return true;
         }
       }
@@ -50,6 +54,20 @@ export default class MySQLAccountStore extends AbstractAccountStore {
       return false;
     }
   }
-  async addLocation(username, location) {}
+  async addLocation(username, location) {
+    const query = "INSERT INTO location (username,location) VALUES (?,?);";
+    const params = [username, location];
+
+    try {
+      const result = await mysqlConnection.promise().query(query, params);
+      const isAddedLocation = result[0]?.affectedRows === 1;
+      if (isAddedLocation) {
+        return true;
+      }
+      return false;
+    } catch (err) {
+      return null;
+    }
+  }
   async removeLocation(username, location) {}
 }

--- a/backend/src/routes/api/account/index.js
+++ b/backend/src/routes/api/account/index.js
@@ -78,10 +78,10 @@ router.delete("/me/location", async (req, res) => {
           .status(INTERNAL_SERVER_ERROR_STATUS)
           .json({ success: false, error: "알 수 없는 오류입니다." });
       }
-      const effectedAccount = await accountStore.getAccount(username);
+      const affectedAccount = await accountStore.getAccount(username);
       res
         .status(SUCCESS_STATUS)
-        .json({ success: true, account: effectedAccount });
+        .json({ success: true, account: affectedAccount });
     } else {
       res.status(BAD_REQUEST).json({
         success: false,

--- a/backend/src/routes/api/account/index.js
+++ b/backend/src/routes/api/account/index.js
@@ -63,8 +63,24 @@ router.delete("/me/location", async (req, res) => {
     const username = req.session["username"];
     const account = await accountStore.getAccount(username);
     if (account.locations.length >= 1) {
-      const account = await accountStore.removeLocation(username, location);
-      res.status(SUCCESS_STATUS).json({ success: true, account });
+      const isLocationExist = account.locations.includes(location);
+      if (!isLocationExist) {
+        return res.status(BAD_REQUEST).json({
+          success: false,
+          error: "해당 지역 정보를 보유하고 있지 않습니다.",
+        });
+      }
+      const isDeletedLocation = await accountStore.removeLocation(
+        username,
+        location
+      );
+      if (!isDeletedLocation) {
+        return res
+          .status(INTERNAL_SERVER_ERROR_STATUS)
+          .json({ success: false, error: "알 수 없는 오류입니다." });
+      }
+      const effectedAccount = await accountStore.getAccount(username);
+      res.status(SUCCESS_STATUS).json({ success: true, effectedAccount });
     } else {
       res.status(BAD_REQUEST).json({
         success: false,

--- a/backend/src/routes/api/account/index.js
+++ b/backend/src/routes/api/account/index.js
@@ -4,12 +4,9 @@ import {
   SUCCESS_STATUS,
   UNAUTHORIZED_STATUS,
 } from "../../../util/HttpStatus.js";
-// import InMemmoryAccountStore from "../../../model/Account/Store/InMemmoryAccountStore.js";
 import MysqlAccountStore from "../../../model/Account/Store/MysqlAccountStore.js";
 
-// const accountStore = new AccountStore();
 const accountStore = new MysqlAccountStore();
-// const accountStore = new InMemmoryAccountStore();
 
 const router = express.Router();
 

--- a/backend/src/routes/api/account/index.js
+++ b/backend/src/routes/api/account/index.js
@@ -43,7 +43,9 @@ router.post("/me/location", async (req, res) => {
           .json({ success: false });
       }
       const updatedAccount = await accountStore.getAccount(username);
-      res.status(SUCCESS_STATUS).json({ success: true, updatedAccount });
+      res
+        .status(SUCCESS_STATUS)
+        .json({ success: true, account: updatedAccount });
     } else {
       res.status(BAD_REQUEST).json({
         success: false,
@@ -80,7 +82,9 @@ router.delete("/me/location", async (req, res) => {
           .json({ success: false, error: "알 수 없는 오류입니다." });
       }
       const effectedAccount = await accountStore.getAccount(username);
-      res.status(SUCCESS_STATUS).json({ success: true, effectedAccount });
+      res
+        .status(SUCCESS_STATUS)
+        .json({ success: true, account: effectedAccount });
     } else {
       res.status(BAD_REQUEST).json({
         success: false,

--- a/backend/src/routes/api/auth/index.js
+++ b/backend/src/routes/api/auth/index.js
@@ -1,8 +1,6 @@
-// import AccountStore from "../../../model/Account/Store/InMemmoryAccountStore.js";
 import MysqlAccountStore from "../../../model/Account/Store/MysqlAccountStore.js";
 import express from "express";
-// const accountStore = new AccountStore(); // MysqlAccountStore로 대체
-const mysqlAccountStore = new MysqlAccountStore();
+const accountStore = new MysqlAccountStore();
 
 const router = express.Router();
 
@@ -10,7 +8,7 @@ const ERROR_MSG_DUPLICATE = "중복된 아이디가 존재합니다.";
 
 router.post("/signin", async (req, res) => {
   const { username } = req.body;
-  const account = await mysqlAccountStore.getAccount(username);
+  const account = await accountStore.getAccount(username);
   if (account) {
     req.session.username = account.username;
     req.session.save(() => {
@@ -23,12 +21,12 @@ router.post("/signin", async (req, res) => {
 
 router.post("/signup", async (req, res) => {
   const { username, location } = req.body;
-  const originAccount = await mysqlAccountStore.getAccount(username);
+  const originAccount = await accountStore.getAccount(username);
   if (originAccount) {
     return res.json({ success: false, error: ERROR_MSG_DUPLICATE });
   }
 
-  const newAccount = await mysqlAccountStore.createAccount({
+  const newAccount = await accountStore.createAccount({
     username,
     location,
   });


### PR DESCRIPTION
#1

## 개요
  - account api MysqlAccountStore로 accountStore 변경 및 auth api 리팩토링
  
## 변경사항
  - account api 의 location 부분 MysqlAccountStore 완성
  - Delete  account/me/location에 없는 location으로 요청시 에러 발생 추가
  - Delete, Post account/me/location 에 MysqlAccountStore 적용
  - account,auth의 AccountStore를 모두 MysqlAccountStore로 변경

## 참고사항

## 추가 구현 필요사항

## 스크린샷
