### PR TITLE
[BE/FE] 상품 상세 화면에서 상품 상태 변화에 대한 구현을 진행했습니다.

### DIFF
--- a/backend/src/model/Product/AbstractProductStore.js
+++ b/backend/src/model/Product/AbstractProductStore.js
@@ -3,6 +3,7 @@ export default class AbstractProductStore {
   getProducts({ location, category }) {}
   getProductById(id) {}
   updateProduct({ id, category, title, content, cost, location, images }) {}
+  updateProductStatus(status) {}
   deleteProductById(id) {}
   getInterestProducts(username) {}
   isInterestProduct(username, productId) {}

--- a/backend/src/model/Product/ProductStatus.js
+++ b/backend/src/model/Product/ProductStatus.js
@@ -1,3 +1,9 @@
 export const PRODUCT_STATUS_SAIL = "SAIL";
 export const PRODUCT_STATUS_SOLD = "SOLD";
 export const PRODUCT_STATUS_RESERVED = "RESERVED";
+
+export const ProductStatus = [
+  PRODUCT_STATUS_SAIL,
+  PRODUCT_STATUS_SOLD,
+  PRODUCT_STATUS_RESERVED,
+];

--- a/backend/src/model/Product/Store/MySQLProductStore.js
+++ b/backend/src/model/Product/Store/MySQLProductStore.js
@@ -143,6 +143,7 @@ export default class MySQLProductStore extends AbstractProductStore {
 
       return new Product({
         id: row.id,
+        author: row.author,
         category: row.category,
         title: row.title,
         content: row.content,
@@ -281,6 +282,21 @@ export default class MySQLProductStore extends AbstractProductStore {
     DELETE FROM interest_product WHERE username = ? AND id =?;
     `;
     const params = [username, productId];
+
+    try {
+      const result = await mysqlConnection.promise().query(query, params);
+      const isSuccess = result[0]?.affectedRows === 1;
+      return isSuccess;
+    } catch (err) {
+      throw err;
+    }
+  }
+
+  async updateProductStatus(id, status) {
+    const params = [status, id];
+    const query = `
+    UPDATE product SET status=? WHERE id = ?;
+    `;
 
     try {
       const result = await mysqlConnection.promise().query(query, params);

--- a/backend/src/routes/api/product/index.js
+++ b/backend/src/routes/api/product/index.js
@@ -38,8 +38,9 @@ router.get("/", async (req, res) => {
 
 router.get("/detail", async (req, res) => {
   const { id } = req.query;
+  const username = req.session["username"];
   try {
-    const product = await productStore.getProductById(id);
+    const product = await productStore.getProductById(id, username);
     if (product === null) {
       return res
         .status(NOT_FOUND_STATUS)
@@ -110,12 +111,11 @@ router.post("/", async (req, res) => {
 
 router.put("/", async (req, res) => {
   const { id, category, title, content, cost, location, images } = req.body;
-  // TODO auth middleware
-  const author = req.session.username;
+  const username = req.session["username"];
 
   try {
-    const targetProduct = await productStore.getProductById(id);
-    if (targetProduct.author !== author) {
+    const targetProduct = await productStore.getProductById(id, username);
+    if (targetProduct.author !== username) {
       return res.status(FORBIDDEN_STATUS).json({ success: false });
     }
   } catch (err) {
@@ -144,7 +144,7 @@ router.delete("/", async (req, res) => {
   const { id } = req.query;
   const username = req.session.username;
   try {
-    const oldProduct = await productStore.getProductById(id);
+    const oldProduct = await productStore.getProductById(id, username);
     if (oldProduct.author !== username) {
       return res.status(402).json({ success: false });
     }

--- a/frontend/src/api/product.js
+++ b/frontend/src/api/product.js
@@ -68,3 +68,15 @@ export const getCategoriesAsync = () =>
     }).then((response) => response.json());
     resolve(request);
   });
+
+export const updateProductStatusAsync = (productId, status) => {
+  return new Promise((resolve, _) => {
+    const request = fetch(`/api/product/${productId}/status?status=${status}`, {
+      method: "PUT",
+      headers: {
+        "Contents-Type": "application/json",
+      },
+    }).then((response) => response.json());
+    resolve(request);
+  });
+};

--- a/frontend/src/api/product.js
+++ b/frontend/src/api/product.js
@@ -31,33 +31,15 @@ export const getMySalingProductsAsync = () => {
   return getProductsAsync();
 };
 
-export const getProductDetail = ({ id }) => {
+export const getProductDetailAsync = ({ id }) => {
   return new Promise((resolve, reject) => {
-    const result = {
-      id: id,
-      images: [
-        "http://img.danawa.com/prod_img/500000/281/013/img/4013281_1.jpg?shrink=500:500&_v=20210129094708",
-        "http://img.danawa.com/prod_img/500000/281/013/img/4013281_1.jpg?shrink=500:500&_v=20210129094708",
-        "http://img.danawa.com/prod_img/500000/281/013/img/4013281_1.jpg?shrink=500:500&_v=20210129094708",
-      ],
-      status: "SOLD",
-      title: "빈티지 롤러 스케이트",
-      category: {
-        id: 1,
-        name: "디지털 기기",
-        icon: "",
+    const request = fetch(`/api/product/detail?id=${id}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
       },
-      updateAt: new Date(),
-      content: "싸게 팝니다~",
-      countOfView: 10,
-      countOfChat: 2,
-      countOfInterest: 10,
-      author: "Woowahan",
-      location: "역삼동",
-      isInterested: true,
-    };
-
-    resolve(result);
+    }).then((response) => response.json());
+    resolve(request);
   });
 };
 

--- a/frontend/src/page/ProductDetailPage/Controller.js
+++ b/frontend/src/page/ProductDetailPage/Controller.js
@@ -1,6 +1,6 @@
 import { navigateTo } from "@/router";
 
-import { getProductDetailAsync } from "@/api/product";
+import { getProductDetailAsync, updateProductStatusAsync } from "@/api/product";
 import {
   getProfileAsync,
   removeInterestProductAsync,
@@ -41,6 +41,14 @@ export default class Controller {
     });
     this.productDetailHeaderView.on("@deletePost", () => {
       navigateTo(`/product-edit/${this.store.productId}`);
+    });
+
+    this.productDetailView.on("@change-status", (e) => {
+      const status = e.detail.value;
+
+      updateProductStatusAsync(this.store.productId, status).then((result) => {
+        this.fetchProductDetailData();
+      });
     });
   }
 

--- a/frontend/src/page/ProductDetailPage/views/ProductDetailHeaderView.js
+++ b/frontend/src/page/ProductDetailPage/views/ProductDetailHeaderView.js
@@ -48,18 +48,18 @@ export default class ProductDetailHeaderView extends View {
   }
 
   show(user, product) {
-    this.element.innerHTML = this.template.getHeadaer({ user, product });
+    this.element.innerHTML = this.template.getHeadaer(user, product);
     super.show();
   }
 }
 
 class Template {
-  getHeadaer({ user, product }) {
+  getHeadaer(user, product) {
     return /*html*/ `
         <a class="header--left" href="/" data-link>
           ${chevronLeftSvg}
         </a>
-      ${user.username === product.author ? this._getSettingButton() : ""}`;
+      ${user?.username === product.author ? this._getSettingButton() : ""}`;
   }
 
   _getSettingButton() {

--- a/frontend/src/page/ProductDetailPage/views/ProductDetailView.js
+++ b/frontend/src/page/ProductDetailPage/views/ProductDetailView.js
@@ -71,6 +71,7 @@ class Template {
       countOfChat,
       countOfInterest,
       countOfView,
+      createdAt,
       author,
       location,
     } = productDetail;
@@ -79,8 +80,8 @@ class Template {
       
       <div class="post-main--title">${title}</div>
       <div class="post-main--sub-title">
-          <p>${category.name}</p>
-          <p>3분 전</p> 
+          <p>${category}</p>
+          <p>${createdAt}</p> 
       </div>
       <div class="post-main--content">
         ${content}

--- a/frontend/src/page/ProductDetailPage/views/ProductDetailView.js
+++ b/frontend/src/page/ProductDetailPage/views/ProductDetailView.js
@@ -3,24 +3,14 @@ import { qs, qsAll } from "@/helper/selectHelpers";
 import { delegate } from "@/helper/eventHelpers";
 
 import chevronDownSvg from "@/public/svg/chevron-down.svg";
-
-const tag = "[ProductDetailView]";
-
-export const STATUS_TYPE = {
-  SALE: "SALE",
-  SOLD: "SOLD",
-  RESERVE: "RESERVE",
-};
-
-const STATUS_TEXT = {
-  [STATUS_TYPE.SALE]: "판매 중",
-  [STATUS_TYPE.SOLD]: "판매 완료",
-  [STATUS_TYPE.RESERVE]: "예약 중",
-};
+import {
+  ProductStatusList,
+  ProductStatusMap,
+  PRODUCT_STATUS_SAIL,
+} from "@/util/productStatus";
 
 export default class ProductDetailView extends View {
   constructor(element = qs("#sale-info"), template = new Template()) {
-    console.log(tag, "constructor");
     super(element);
     this.template = template;
     this.bindingEvents();
@@ -45,6 +35,9 @@ export default class ProductDetailView extends View {
         if ($menu) {
           this.toggleDropDownMenu(false);
         }
+      } else {
+        const status = e.target.dataset.status;
+        this.emit("@change-status", { value: status });
       }
     });
   }
@@ -58,6 +51,7 @@ export default class ProductDetailView extends View {
 
   show(user, productDetail) {
     this.element.innerHTML = this.template.getDetail(user, productDetail);
+    super.show();
   }
 }
 
@@ -76,7 +70,7 @@ class Template {
       location,
     } = productDetail;
     return `
-      ${user.username === author ? this.getStatusSelector(status) : ""}
+      ${user?.username === author ? this._getStatusSelector(status) : ""}
       
       <div class="post-main--title">${title}</div>
       <div class="post-main--sub-title">
@@ -99,32 +93,32 @@ class Template {
     `;
   }
 
-  getStatusSelector(status = STATUS_TYPE.SOLD) {
-    const statusList = Object.values(STATUS_TYPE);
-
+  _getStatusSelector(status = PRODUCT_STATUS_SAIL) {
     return `
-        <div  id="sale-status">
-            ${this._getSaleStatusDropDown(statusList)}
+        <div id="sale-status">
+            ${this._getSaleStatusDropDown(status)}
         </div>
       `;
   }
 
-  _getSaleStatusDropDown(statusList = []) {
+  _getSaleStatusDropDown(currentStatus) {
     return /*html*/ `
         <div class="post-main--sale-status" class="dropdown-wrapper">
             <div class="dropdown-wrapper--toggle post-main--sale-status--content">
-                <p>판매 중</p>
+                <p>${ProductStatusMap[currentStatus]}</p>
                 <div class="location-icon"> ${chevronDownSvg}</div>
             </div>
             <div class="dropdown-wrapper--menu small" aria-expanded="false">
-                ${statusList
-                  .map((status) => this._getSaleStatusItem(status))
-                  .join("")}
+                ${ProductStatusList.map((status) =>
+                  this._getSaleStatusItem(status)
+                ).join("")}
             </div>
         </div>`;
   }
 
   _getSaleStatusItem(status) {
-    return /* html */ `<div class="dropdown-wrapper--menu--item center post-main--sale-status--menu-item" data-status="${status}">${STATUS_TEXT[status]}</div>`;
+    return /* html */ `
+    <div class="dropdown-wrapper--menu--item center post-main--sale-status--menu-item" 
+                              data-status="${status}">${ProductStatusMap[status]}</div>`;
   }
 }

--- a/frontend/src/page/ProductDetailPage/views/ProductImageListView.js
+++ b/frontend/src/page/ProductDetailPage/views/ProductImageListView.js
@@ -29,10 +29,14 @@ export default class ProductImageListView extends View {
     });
   }
 
-  show(images) {
-    this.element.innerHTML = this.template.getImages(images);
-    this.imageLength = images.length;
-    this.$images = qs(".images", this.element);
+  show(images = []) {
+    if (images.length > 0) {
+      this.element.innerHTML = this.template.getImages(images);
+      this.imageLength = images.length;
+      this.$images = qs(".images", this.element);
+    } else {
+      this.element.innerHTML = "<h1>등록된 이미지가 없습니다.</h2>";
+    }
     super.show();
   }
 
@@ -70,7 +74,7 @@ export default class ProductImageListView extends View {
 }
 
 class Template {
-  imagesToElements(images) {
+  imagesToElements(images = []) {
     const elementArray = images.map(
       (image) => `
       <img src=${image} />

--- a/frontend/src/public/css/detailPost.css
+++ b/frontend/src/public/css/detailPost.css
@@ -69,7 +69,7 @@ main {
 #sale-info {
   margin-left: 16px;
   margin-right: 16px;
-  margin-top: 24px;
+  margin-top: 12px;
   display: flex;
   flex-direction: column;
 }
@@ -78,15 +78,15 @@ main {
   position: relative;
   display: flex;
   justify-content: center;
-  width: 100px;
+  width: 120px;
   align-items: center;
-  padding: 10px 16px;
   border: 1px solid #e0e0e0;
   border-radius: 8px;
   cursor: pointer;
 }
 
 .post-main--sale-status--content {
+  height: 40px;
   flex-grow: 1;
   display: flex;
   justify-content: space-around;

--- a/frontend/src/util/productStatus.js
+++ b/frontend/src/util/productStatus.js
@@ -1,0 +1,15 @@
+export const PRODUCT_STATUS_SAIL = "SAIL";
+export const PRODUCT_STATUS_SOLD = "SOLD";
+export const PRODUCT_STATUS_RESERVED = "RESERVED";
+
+export const ProductStatusList = [
+  PRODUCT_STATUS_SAIL,
+  PRODUCT_STATUS_SOLD,
+  PRODUCT_STATUS_RESERVED,
+];
+
+export const ProductStatusMap = {
+  [PRODUCT_STATUS_SAIL]: "판매 중",
+  [PRODUCT_STATUS_SOLD]: "판매 완료",
+  [PRODUCT_STATUS_RESERVED]: "예약 중",
+};


### PR DESCRIPTION
## 개요

상품 상세 기능 화면에서 `GET /api/product/[product id]/detail` API를 이용해서 데이터를 보여주는 작업과 상품 게시글의 작성자가 상품 게시글의 상태(SAIL, SOLD, RESERVED) 를 변경하는 기능을 추가했습니다.

## 변경사항

- `/api/prodcut/[product id]/status?status=SOLD` API구현을 했습니다.

현재 이미지 업로드 기능이 구현되어있지않아서 이미지가 없을시 이미지 Carousel UI는 "이미지가 없습니다."로 대체해놨습니다.
추후 상품 글쓰기 기능과 이미지 업로드 기능이 완료되면 변경해야합니다.

## 참고사항

관심 목록 추가 혹은 상태 변경에도 조회수가 올라가는 현상이 있습니다. 쿼리문을 수정하던가 아니면 서버의 API 로직을 수정할 필요가 있습니다.

## 추가 구현 필요사항

이미지 등록 관련 진행을 위해서 글쓰기 작업을 우선적으로 작업해보겠습니다.

## 스크린샷
<img width="337" alt="스크린샷 2021-07-20 오후 4 42 16" src="https://user-images.githubusercontent.com/20085849/126281814-0932ca84-3e65-4d07-ad5a-d327bc9a3926.png">

