### PR TITLE
[Frontend] ChatList 화면 및 채팅관련 URL 들을 수정하였습니다.

### DIFF
--- a/frontend/public/css/chatList.css
+++ b/frontend/public/css/chatList.css
@@ -1,5 +1,5 @@
-@import url('./common/basic_header.css');
-@import url('./common/chat_list_item.css');
+@import url("./common/basic_header.css");
+@import url("./common/chat_list_item.css");
 body {
   background-color: #fff;
 }

--- a/frontend/public/css/common/product_list_item.css
+++ b/frontend/public/css/common/product_list_item.css
@@ -97,3 +97,7 @@
 .content--product--info--bottom > div:last-child {
   margin-right: 0;
 }
+
+.content--chat-item--right--right > img {
+  width: 100%;
+}

--- a/frontend/src/api/chat.js
+++ b/frontend/src/api/chat.js
@@ -37,6 +37,11 @@ export const getChatRoomsAsync = () => {
   });
 };
 
+export const getChatRoomsByProductAsync = (productId) => {
+  // TODO: productId 별로 채팅리스트를 가져와야함 (판매자만 가능)
+  return getChatRoomsAsync();
+};
+
 export const getChatRoomAsync = (productId) => {
   return new Promise((resolve, reject) => {
     setTimeout(() => {

--- a/frontend/src/api/chat.js
+++ b/frontend/src/api/chat.js
@@ -5,7 +5,8 @@ export const getChatRoomsAsync = () => {
         {
           key: "550e8400-e29b-41d4-a716-446655440000",
           targetUser: "UserA",
-          product: 4002,
+          product: 0,
+          unReadCount: 1,
           productThumbnail:
             "http://img.danawa.com/prod_img/500000/281/013/img/4013281_1.jpg?shrink=500:500&_v=20210129094708",
           lastChat: {
@@ -19,7 +20,8 @@ export const getChatRoomsAsync = () => {
         {
           key: "550e8400-e29b-41d4-a716-446655440000",
           targetUser: "UserC",
-          product: 4002,
+          product: 0,
+          unReadCount: 0,
           productThumbnail:
             "http://img.danawa.com/prod_img/500000/281/013/img/4013281_1.jpg?shrink=500:500&_v=20210129094708",
           lastChat: {

--- a/frontend/src/api/chat.js
+++ b/frontend/src/api/chat.js
@@ -5,7 +5,7 @@ export const getChatRoomsAsync = () => {
         {
           key: "550e8400-e29b-41d4-a716-446655440000",
           targetUser: "UserA",
-          product: 0,
+          productId: 0,
           unReadCount: 1,
           productThumbnail:
             "http://img.danawa.com/prod_img/500000/281/013/img/4013281_1.jpg?shrink=500:500&_v=20210129094708",
@@ -20,7 +20,7 @@ export const getChatRoomsAsync = () => {
         {
           key: "550e8400-e29b-41d4-a716-446655440000",
           targetUser: "UserC",
-          product: 0,
+          productId: 0,
           unReadCount: 0,
           productThumbnail:
             "http://img.danawa.com/prod_img/500000/281/013/img/4013281_1.jpg?shrink=500:500&_v=20210129094708",

--- a/frontend/src/api/user.js
+++ b/frontend/src/api/user.js
@@ -6,7 +6,6 @@ export const getProfileAsync = () =>
         "Content-Type": "application/json",
       },
     }).then((response) => response.json());
-
     resolve(request);
   });
 
@@ -20,8 +19,7 @@ export const addLocationAsync = (location) => {
       body: JSON.stringify({
         location: location,
       }),
-    }).then((response) => response.json());
-    resolve(request);
+    }).then((response) => resolve(response.json()));
   });
 };
 
@@ -32,8 +30,7 @@ export const removeLocationAsync = (location) => {
       headers: {
         "Content-Type": "application/json",
       },
-    }).then((response) => response.json());
-    resolve(request);
+    }).then((response) => resolve(response.json()));
   });
 };
 

--- a/frontend/src/page/ChatRoomListPage/Controller.js
+++ b/frontend/src/page/ChatRoomListPage/Controller.js
@@ -1,4 +1,4 @@
-import { getChatRoomsAsync } from "@/api/chat";
+import { getChatRoomsByProductAsync } from "@/api/chat";
 
 export default class Controller {
   constructor(
@@ -14,7 +14,7 @@ export default class Controller {
   }
 
   init() {
-    getChatRoomsAsync().then((roomInfos) => {
+    getChatRoomsByProductAsync(this.productId).then((roomInfos) => {
       this.store.roomInfos = roomInfos;
       this.render();
     });
@@ -22,7 +22,6 @@ export default class Controller {
 
   render() {
     const { roomInfos } = this.store;
-    console.log(roomInfos);
     this.chatRoomListHeaderView.show(this.productId);
     this.chatRoomListContentView.show(roomInfos);
   }

--- a/frontend/src/page/ChatRoomListPage/Controller.js
+++ b/frontend/src/page/ChatRoomListPage/Controller.js
@@ -1,8 +1,29 @@
+import { getChatRoomsAsync } from "@/api/chat";
+
 export default class Controller {
-  constructor({ chatRoomListHeaderView }) {
-    this.chatRoomListHeaderView = new ChatRoomListHeaderView();
-    this.render();
+  constructor(
+    store,
+    productId,
+    { chatRoomListHeaderView, chatRoomListContentView }
+  ) {
+    this.chatRoomListHeaderView = chatRoomListHeaderView;
+    this.chatRoomListContentView = chatRoomListContentView;
+    this.store = store;
+    this.productId = productId;
+    this.init();
   }
 
-  render() {}
+  init() {
+    getChatRoomsAsync().then((roomInfos) => {
+      this.store.roomInfos = roomInfos;
+      this.render();
+    });
+  }
+
+  render() {
+    const { roomInfos } = this.store;
+    console.log(roomInfos);
+    this.chatRoomListHeaderView.show(this.productId);
+    this.chatRoomListContentView.show(roomInfos);
+  }
 }

--- a/frontend/src/page/ChatRoomListPage/Controller.js
+++ b/frontend/src/page/ChatRoomListPage/Controller.js
@@ -1,0 +1,8 @@
+export default class Controller {
+  constructor({ chatRoomListHeaderView }) {
+    this.chatRoomListHeaderView = new ChatRoomListHeaderView();
+    this.render();
+  }
+
+  render() {}
+}

--- a/frontend/src/page/ChatRoomListPage/Store.js
+++ b/frontend/src/page/ChatRoomListPage/Store.js
@@ -1,0 +1,14 @@
+export default class Store {
+  constructor() {
+    this.roomsInfos = [];
+    /*
+        this.roomKey = undefined;
+        this.targetUser = undefined;
+        this.productId = undefined;
+        this.unreadCount = 0;
+        this.productThumbnail = undefined;
+        this.chatLogs = [];
+        this.totalMessageCount = 0;
+    */
+  }
+}

--- a/frontend/src/page/ChatRoomListPage/index.js
+++ b/frontend/src/page/ChatRoomListPage/index.js
@@ -1,0 +1,66 @@
+import AbstractPage from "../AbstractPage";
+
+export default class ChatRoomListPage extends AbstractPage {
+  constructor(params) {
+    super(params);
+  }
+  async render() {
+    return /*html*/ `
+      <header class="header">
+        <a class="header--left" href="./detailPost.html">
+          <img src="./icon/chevron-left.svg" />
+        </a>
+        <h1 class="header--center">
+          <span class="header--center--title"> 채팅하기 </span>
+        </h1>
+      </header>
+  <div class="content">
+    <article class="content--chat-item unread">
+      <div class="content--chat-item--left">
+        <strong class="username">UserC</strong>
+        <span class="current-message">혹시 팔렸나요?</span>
+      </div>
+      <div class="content--chat-item--right">
+        <div class="content--chat-item--right--left">
+          <div><span class="current-chat-time">15분전</span></div>
+          <div><div class="un-read-count">1</div></div>
+        </div>
+        <a class="content--chat-item--right--right">
+          <img src="/image/example-cooler.svg" alt="상품 썸네일 사진" />
+        </a>
+      </div>
+    </article>
+    <article class="content--chat-item unread">
+      <div class="content--chat-item--left">
+        <strong class="username">UserC</strong>
+        <span class="current-message">혹시 팔렸나요?</span>
+      </div>
+      <div class="content--chat-item--right">
+        <div class="content--chat-item--right--left">
+          <div><span class="current-chat-time">15분전</span></div>
+          <div><div class="un-read-count">1</div></div>
+        </div>
+        <a class="content--chat-item--right--right">
+          <img src="/image/example-cooler.svg" alt="상품 썸네일 사진" />
+        </a>
+      </div>
+    </article>
+    <article class="content--chat-item">
+      <div class="content--chat-item--left">
+        <strong class="username">UserC</strong>
+        <span class="current-message">혹시 팔렸나요?</span>
+      </div>
+      <div class="content--chat-item--right">
+        <div class="content--chat-item--right--left">
+          <div><span class="current-chat-time">15분전</span></div>
+          <div></div>
+        </div>
+        <a class="content--chat-item--right--right">
+          <img src="/image/example-cooler.svg" alt="상품 썸네일 사진" />
+        </a>
+      </div>
+    </article>
+  </div>  
+    `;
+  }
+}

--- a/frontend/src/page/ChatRoomListPage/index.js
+++ b/frontend/src/page/ChatRoomListPage/index.js
@@ -1,12 +1,15 @@
 import AbstractPage from "../AbstractPage";
 
 import Controller from "./Controller";
+import Store from "./Store";
 
-import ChatRoomListHeaderView from "./view/ChatRoomListHeaderView.js";
+import ChatRoomListHeaderView from "./views/ChatRoomListHeaderView";
+import ChatroomListContentView from "./views/ChatroomListContentView";
 
 export default class ChatRoomListPage extends AbstractPage {
   constructor(params) {
     super(params);
+    this.productId = params.productId;
   }
   async render() {
     return /*html*/ `
@@ -14,51 +17,6 @@ export default class ChatRoomListPage extends AbstractPage {
       
       </header>
       <div class="content">
-        <article class="content--chat-item unread">
-          <div class="content--chat-item--left">
-            <strong class="username">UserC</strong>
-            <span class="current-message">혹시 팔렸나요?</span>
-          </div>
-          <div class="content--chat-item--right">
-            <div class="content--chat-item--right--left">
-              <div><span class="current-chat-time">15분전</span></div>
-              <div><div class="un-read-count">1</div></div>
-            </div>
-            <a class="content--chat-item--right--right">
-              <img src="/image/example-cooler.svg" alt="상품 썸네일 사진" />
-            </a>
-          </div>
-        </article>
-        <article class="content--chat-item unread">
-          <div class="content--chat-item--left">
-            <strong class="username">UserC</strong>
-            <span class="current-message">혹시 팔렸나요?</span>
-          </div>
-          <div class="content--chat-item--right">
-            <div class="content--chat-item--right--left">
-              <div><span class="current-chat-time">15분전</span></div>
-              <div><div class="un-read-count">1</div></div>
-            </div>
-            <a class="content--chat-item--right--right">
-              <img src="/image/example-cooler.svg" alt="상품 썸네일 사진" />
-            </a>
-          </div>
-        </article>
-        <article class="content--chat-item">
-          <div class="content--chat-item--left">
-            <strong class="username">UserC</strong>
-            <span class="current-message">혹시 팔렸나요?</span>
-          </div>
-          <div class="content--chat-item--right">
-            <div class="content--chat-item--right--left">
-              <div><span class="current-chat-time">15분전</span></div>
-              <div></div>
-            </div>
-            <a class="content--chat-item--right--right">
-              <img src="/image/example-cooler.svg" alt="상품 썸네일 사진" />
-            </a>
-          </div>
-        </article>
       </div>  
     `;
   }
@@ -66,7 +24,9 @@ export default class ChatRoomListPage extends AbstractPage {
   after_render() {
     const views = {
       chatRoomListHeaderView: new ChatRoomListHeaderView(),
+      chatRoomListContentView: new ChatroomListContentView(),
     };
-    new Controller(views);
+    const store = new Store();
+    new Controller(store, this.productId, views);
   }
 }

--- a/frontend/src/page/ChatRoomListPage/index.js
+++ b/frontend/src/page/ChatRoomListPage/index.js
@@ -1,5 +1,9 @@
 import AbstractPage from "../AbstractPage";
 
+import Controller from "./Controller";
+
+import ChatRoomListHeaderView from "./view/ChatRoomListHeaderView.js";
+
 export default class ChatRoomListPage extends AbstractPage {
   constructor(params) {
     super(params);
@@ -7,60 +11,62 @@ export default class ChatRoomListPage extends AbstractPage {
   async render() {
     return /*html*/ `
       <header class="header">
-        <a class="header--left" href="./detailPost.html">
-          <img src="./icon/chevron-left.svg" />
-        </a>
-        <h1 class="header--center">
-          <span class="header--center--title"> 채팅하기 </span>
-        </h1>
+      
       </header>
-  <div class="content">
-    <article class="content--chat-item unread">
-      <div class="content--chat-item--left">
-        <strong class="username">UserC</strong>
-        <span class="current-message">혹시 팔렸나요?</span>
-      </div>
-      <div class="content--chat-item--right">
-        <div class="content--chat-item--right--left">
-          <div><span class="current-chat-time">15분전</span></div>
-          <div><div class="un-read-count">1</div></div>
-        </div>
-        <a class="content--chat-item--right--right">
-          <img src="/image/example-cooler.svg" alt="상품 썸네일 사진" />
-        </a>
-      </div>
-    </article>
-    <article class="content--chat-item unread">
-      <div class="content--chat-item--left">
-        <strong class="username">UserC</strong>
-        <span class="current-message">혹시 팔렸나요?</span>
-      </div>
-      <div class="content--chat-item--right">
-        <div class="content--chat-item--right--left">
-          <div><span class="current-chat-time">15분전</span></div>
-          <div><div class="un-read-count">1</div></div>
-        </div>
-        <a class="content--chat-item--right--right">
-          <img src="/image/example-cooler.svg" alt="상품 썸네일 사진" />
-        </a>
-      </div>
-    </article>
-    <article class="content--chat-item">
-      <div class="content--chat-item--left">
-        <strong class="username">UserC</strong>
-        <span class="current-message">혹시 팔렸나요?</span>
-      </div>
-      <div class="content--chat-item--right">
-        <div class="content--chat-item--right--left">
-          <div><span class="current-chat-time">15분전</span></div>
-          <div></div>
-        </div>
-        <a class="content--chat-item--right--right">
-          <img src="/image/example-cooler.svg" alt="상품 썸네일 사진" />
-        </a>
-      </div>
-    </article>
-  </div>  
+      <div class="content">
+        <article class="content--chat-item unread">
+          <div class="content--chat-item--left">
+            <strong class="username">UserC</strong>
+            <span class="current-message">혹시 팔렸나요?</span>
+          </div>
+          <div class="content--chat-item--right">
+            <div class="content--chat-item--right--left">
+              <div><span class="current-chat-time">15분전</span></div>
+              <div><div class="un-read-count">1</div></div>
+            </div>
+            <a class="content--chat-item--right--right">
+              <img src="/image/example-cooler.svg" alt="상품 썸네일 사진" />
+            </a>
+          </div>
+        </article>
+        <article class="content--chat-item unread">
+          <div class="content--chat-item--left">
+            <strong class="username">UserC</strong>
+            <span class="current-message">혹시 팔렸나요?</span>
+          </div>
+          <div class="content--chat-item--right">
+            <div class="content--chat-item--right--left">
+              <div><span class="current-chat-time">15분전</span></div>
+              <div><div class="un-read-count">1</div></div>
+            </div>
+            <a class="content--chat-item--right--right">
+              <img src="/image/example-cooler.svg" alt="상품 썸네일 사진" />
+            </a>
+          </div>
+        </article>
+        <article class="content--chat-item">
+          <div class="content--chat-item--left">
+            <strong class="username">UserC</strong>
+            <span class="current-message">혹시 팔렸나요?</span>
+          </div>
+          <div class="content--chat-item--right">
+            <div class="content--chat-item--right--left">
+              <div><span class="current-chat-time">15분전</span></div>
+              <div></div>
+            </div>
+            <a class="content--chat-item--right--right">
+              <img src="/image/example-cooler.svg" alt="상품 썸네일 사진" />
+            </a>
+          </div>
+        </article>
+      </div>  
     `;
+  }
+
+  after_render() {
+    const views = {
+      chatRoomListHeaderView: new ChatRoomListHeaderView(),
+    };
+    new Controller(views);
   }
 }

--- a/frontend/src/page/ChatRoomListPage/views/ChatRoomListContentView.js
+++ b/frontend/src/page/ChatRoomListPage/views/ChatRoomListContentView.js
@@ -1,0 +1,53 @@
+import View from "@/page/View";
+import { qs } from "@/helper/selectHelpers.js";
+
+import "@/public/css/common/product_list_item.css";
+
+export default class ChatRoomListContentView extends View {
+  constructor(element = qs(".content")) {
+    super(element);
+  }
+
+  show(roomInfos) {
+    roomInfos.forEach((roomInfo) => {
+      const $newChatArticle = document.createElement("article");
+      $newChatArticle.className = `content--chat-item ${
+        roomInfo.unReadCount <= 0 ? "" : "unread"
+      }`;
+
+      $newChatArticle.dataset.roomKey = roomInfo.roomKey;
+      this.element.appendChild($newChatArticle);
+      $newChatArticle.innerHTML = this.getChatArticle(roomInfo);
+    });
+  }
+
+  getChatArticle(roomInfo) {
+    const { targetUser, productThumbnail, unReadCount, lastChat } = roomInfo;
+
+    return `
+      <div class="content--chat-item--left">
+        <strong class="username">${targetUser}</strong>
+        <span class="current-message">${lastChat.message}</span>
+      </div>
+      <div class="content--chat-item--right">
+        <div class="content--chat-item--right--left">
+          <!-- TODO: 시간차이 구하는 함수 구현 및 적용 -->
+          <div><span class="current-chat-time">${"15분전"}</span></div>
+          <div>
+            ${
+              unReadCount <= 0
+                ? ""
+                : `
+              <div class="un-read-count">${unReadCount}</div>
+            `
+            }
+            
+          </div>
+        </div>
+        <a class="content--chat-item--right--right">
+          <img src="${productThumbnail}" alt="상품 썸네일 사진" />
+        </a>
+      </div>
+    `;
+  }
+}

--- a/frontend/src/page/ChatRoomListPage/views/ChatRoomListContentView.js
+++ b/frontend/src/page/ChatRoomListPage/views/ChatRoomListContentView.js
@@ -51,10 +51,9 @@ export default class ChatRoomListContentView extends View {
               unReadCount <= 0
                 ? ""
                 : `
-              <div class="un-read-count">${unReadCount}</div>
-            `
+                  <div class="un-read-count">${unReadCount}</div>
+                `
             }
-            
           </div>
         </div>
         <a class="content--chat-item--right--right">

--- a/frontend/src/page/ChatRoomListPage/views/ChatRoomListContentView.js
+++ b/frontend/src/page/ChatRoomListPage/views/ChatRoomListContentView.js
@@ -2,11 +2,25 @@ import View from "@/page/View";
 import { qs } from "@/helper/selectHelpers.js";
 
 import "@/public/css/common/product_list_item.css";
+import { delegate } from "@/helper/eventHelpers";
+import { navigateTo } from "@/router";
 
 export default class ChatRoomListContentView extends View {
   constructor(element = qs(".content")) {
     super(element);
+    this.bindingEvents();
   }
+
+  bindingEvents() {
+    delegate(this.element, "click", ".content--chat-item", (event) => {
+      this.handleChatRoomClick(event);
+    });
+  }
+
+  handleChatRoomClick = (event) => {
+    const roomKey = event.target.dataset.roomKey;
+    navigateTo(`/chat/${roomKey}`);
+  };
 
   show(roomInfos) {
     roomInfos.forEach((roomInfo) => {
@@ -14,8 +28,7 @@ export default class ChatRoomListContentView extends View {
       $newChatArticle.className = `content--chat-item ${
         roomInfo.unReadCount <= 0 ? "" : "unread"
       }`;
-
-      $newChatArticle.dataset.roomKey = roomInfo.roomKey;
+      $newChatArticle.dataset.roomKey = roomInfo.key;
       this.element.appendChild($newChatArticle);
       $newChatArticle.innerHTML = this.getChatArticle(roomInfo);
     });

--- a/frontend/src/page/ChatRoomListPage/views/chatRoomListHeaderView.js
+++ b/frontend/src/page/ChatRoomListPage/views/chatRoomListHeaderView.js
@@ -1,22 +1,24 @@
 import View from "@/page/View";
+import { qs } from "@/helper/selectHelpers.js";
+
+import chevronLeftSvg from "@/public/svg/chevron-left.svg";
 
 export default class ChatRoomListHeaderView extends View {
   constructor(element = qs(".header"), template = new Template()) {
     super(element);
     this.template = template;
-    this.bindingEvents();
   }
 
-  show() {
-    this.element.innerHTML = this.template.getContent;
+  show(productId) {
+    this.element.innerHTML = this.template.getContent(productId);
   }
 }
 
 class Template {
-  getContent() {
+  getContent(productId) {
     return `
-    <a class="header--left" href="./detailPost.html">
-        <img src="./icon/chevron-left.svg" />
+    <a class="header--left" href="/product/${productId}">
+      ${chevronLeftSvg}
     </a>
     <h1 class="header--center">
         <span class="header--center--title"> 채팅하기 </span>

--- a/frontend/src/page/ChatRoomListPage/views/chatRoomListHeaderView.js
+++ b/frontend/src/page/ChatRoomListPage/views/chatRoomListHeaderView.js
@@ -1,0 +1,26 @@
+import View from "@/page/View";
+
+export default class ChatRoomListHeaderView extends View {
+  constructor(element = qs(".header"), template = new Template()) {
+    super(element);
+    this.template = template;
+    this.bindingEvents();
+  }
+
+  show() {
+    this.element.innerHTML = this.template.getContent;
+  }
+}
+
+class Template {
+  getContent() {
+    return `
+    <a class="header--left" href="./detailPost.html">
+        <img src="./icon/chevron-left.svg" />
+    </a>
+    <h1 class="header--center">
+        <span class="header--center--title"> 채팅하기 </span>
+    </h1>
+    `;
+  }
+}

--- a/frontend/src/page/ChatRoomPage/Controller.js
+++ b/frontend/src/page/ChatRoomPage/Controller.js
@@ -4,7 +4,7 @@ import { navigateTo } from "@/router";
 export default class Controller {
   constructor(
     store,
-    productId,
+    roomId,
     {
       chatRoomHeaderView,
       chatRoomAlertModalView,
@@ -18,7 +18,7 @@ export default class Controller {
     this.chatRoomMainContentView = chatRoomMainContentView;
 
     this.store = store;
-    this.productId = productId;
+    this.roomId = roomId;
     this.subscribeViewEvents();
 
     this.init();
@@ -26,7 +26,7 @@ export default class Controller {
 
   subscribeViewEvents() {
     this.chatRoomAlertModalView.on("@exit-room", () => {
-      exitChatRoomAsync(this.productId).then((result) => {
+      exitChatRoomAsync(this.roomId).then((result) => {
         if (result.success) {
           navigateTo("/");
         }
@@ -35,10 +35,10 @@ export default class Controller {
   }
 
   init() {
-    getChatRoomAsync(this.productId).then((roomInfo) => {
+    getChatRoomAsync(this.roomId).then((roomInfo) => {
       this.store.roomKey = roomInfo?.key;
       this.store.targetUser = roomInfo?.targetUser;
-      this.store.productId = roomInfo?.productId;
+      this.store.roomId = roomInfo?.roomId;
       this.store.productTitle = roomInfo?.productTitle;
       this.store.productThumbnail = roomInfo?.productThumbnail;
       this.store.productCost = roomInfo?.productCost;

--- a/frontend/src/page/ChatRoomPage/Store.js
+++ b/frontend/src/page/ChatRoomPage/Store.js
@@ -2,7 +2,7 @@ export default class Store {
   constructor() {
     this.roomKey = undefined;
     this.targetUser = undefined;
-    this.productId = undefined;
+    this.roomId = undefined;
     this.productThumbnail = undefined;
     this.chatLogs = [];
     this.totalMessageCount = 0;

--- a/frontend/src/page/ChatRoomPage/index.js
+++ b/frontend/src/page/ChatRoomPage/index.js
@@ -16,7 +16,7 @@ export default class ChatRoomPage extends AbstractPage {
   constructor(params) {
     super(params);
     this.setTitle("Chat Room");
-    this.productId = params.productId;
+    this.roomId = params.roomId;
   }
 
   async render() {
@@ -54,6 +54,6 @@ export default class ChatRoomPage extends AbstractPage {
       chatRoomMainContentView: new ChatRoomMainContentView(),
     };
     const store = new Store();
-    new Controller(store, this.productId, views);
+    new Controller(store, this.roomId, views);
   }
 }

--- a/frontend/src/page/CreatePostPage/Controller.js
+++ b/frontend/src/page/CreatePostPage/Controller.js
@@ -101,8 +101,11 @@ export default class Controller {
         comment,
         location,
         category: category.id,
-      }).then((id) => {
-        navigateTo("/product/" + id);
+      }).then((result) => {
+        if (result.success) {
+          const { id } = result;
+          navigateTo("/product/" + id);
+        }
       });
 
       // TODO: add image upload api

--- a/frontend/src/page/ProductDetailPage/Controller.js
+++ b/frontend/src/page/ProductDetailPage/Controller.js
@@ -1,5 +1,6 @@
 import { navigateTo } from "@/router";
 
+import { getChatRoomAsync } from "@/api/chat";
 import { getProductDetailAsync, updateProductStatusAsync } from "@/api/product";
 import {
   getProfileAsync,
@@ -34,6 +35,23 @@ export default class Controller {
     this.productDetailFooterView.on("@interest", (e) => {
       const { id, isInterested } = e.detail.value;
       this.changeInterest(id, isInterested);
+    });
+
+    this.productDetailFooterView.on("@make-chat-room", () => {
+      const isAuthed = this.store.user !== undefined;
+      getChatRoomAsync()
+        .then((roomInfo) => {
+          const { key } = roomInfo;
+          if (key) {
+            navigateTo(`/chat/${key}`);
+            return;
+          }
+          throw "key of roomInfo is not returned!";
+        })
+        .catch((err) => {
+          navigateTo("/");
+          throw err;
+        });
     });
 
     this.productDetailHeaderView.on("@modifyPost", () => {

--- a/frontend/src/page/ProductDetailPage/views/ProductDetailFooterView.js
+++ b/frontend/src/page/ProductDetailPage/views/ProductDetailFooterView.js
@@ -18,6 +18,9 @@ export default class ProductDetailFooterView extends View {
     delegate(this.element, "click", "#interest-btn", (e) => {
       this.handleClickInterestEvent(e);
     });
+    delegate(this.element, "click", "#getChatRoom", (e) => {
+      this.handleClickGetChatRoom(e);
+    });
   }
 
   handleClickInterestEvent(event) {
@@ -28,7 +31,9 @@ export default class ProductDetailFooterView extends View {
       value: { id, isInterested: !currentInterestStatus },
     });
   }
-
+  handleClickGetChatRoom(event) {
+    this.emit("@make-chat-room");
+  }
   show(user, productDetail) {
     this.element.innerHTML = this.template.getFooter(user, productDetail);
     super.show();
@@ -49,12 +54,12 @@ class Template {
           user?.username === author
             ? `
                 <a href="/chatList/${id}" data-link>
-                    <div class="move-btn">채팅 목록 보기 (2)</div>
+                    <div class="move-btn">채팅 목록 보기 (2)</div> <!-- chatList/:productId -->
                 </a>`
             : `
-                <a href="/chat/${id}" data-link>
-                    <div class="move-btn">문의하기</div>
-                </a>`
+                <div>
+                    <div class="move-btn" id="getChatRoom">문의하기</div> <!-- chat/:roomId --> 
+                <div>`
         }
             
       `;

--- a/frontend/src/page/ProductDetailPage/views/ProductDetailFooterView.js
+++ b/frontend/src/page/ProductDetailPage/views/ProductDetailFooterView.js
@@ -18,7 +18,7 @@ export default class ProductDetailFooterView extends View {
     delegate(this.element, "click", "#interest-btn", (e) => {
       this.handleClickInterestEvent(e);
     });
-    delegate(this.element, "click", "#getChatRoom", (e) => {
+    delegate(this.element, "click", "#get-chatRoom", (e) => {
       this.handleClickGetChatRoom(e);
     });
   }
@@ -54,11 +54,11 @@ class Template {
           user?.username === author
             ? `
                 <a href="/chatList/${id}" data-link>
-                    <div class="move-btn">채팅 목록 보기 (2)</div> <!-- chatList/:productId -->
+                    <div class="move-btn">채팅 목록 보기 (2)</div> 
                 </a>`
             : `
                 <div>
-                    <div class="move-btn" id="getChatRoom">문의하기</div> <!-- chat/:roomId --> 
+                    <div class="move-btn" id="get-chatRoom">문의하기</div> 
                 <div>`
         }
             

--- a/frontend/src/public/css/common/chat_list_item.css
+++ b/frontend/src/public/css/common/chat_list_item.css
@@ -118,3 +118,11 @@
   text-align: center;
   color: var(--gray-text-color);
 }
+
+.content--chat-item {
+  cursor: pointer;
+}
+
+.content--chat-item * {
+  pointer-events: none;
+}

--- a/frontend/src/public/css/common/product_list_item.css
+++ b/frontend/src/public/css/common/product_list_item.css
@@ -152,3 +152,7 @@
   text-align: center;
   color: var(--gray-text-color);
 }
+
+.content--chat-item--right--right > img {
+  width: 100%;
+}

--- a/frontend/src/public/css/detailPost.css
+++ b/frontend/src/public/css/detailPost.css
@@ -186,6 +186,7 @@ footer .move-btn {
   font-weight: 500;
   padding: 8px 16px;
   border-radius: 8px;
+  cursor: pointer;
 }
 
 .interest-btn {

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -7,6 +7,7 @@ import ProductDetailPage from "./page/ProductDetailPage";
 import CreatePostPage from "./page/CreatePostPage";
 import LocationPage from "./page/LocationPage/index";
 import ChatRoomPage from "./page/ChatRoomPage/index";
+import ChatRoomListPage from "./page/ChatRoomListPage";
 
 const pathToRegex = (path) =>
   new RegExp("^" + path.replace(/\//g, "\\/").replace(/:\w+/g, "(.+)") + "$");
@@ -39,6 +40,7 @@ export const router = async () => {
     { path: "/product/:productId", view: ProductDetailPage },
     { path: "/createPost", view: CreatePostPage },
     { path: "/location", view: LocationPage },
+    { path: "/chatList/:productId", view: ChatRoomListPage },
     { path: "/chat/:productId", view: ChatRoomPage },
   ];
 

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -41,7 +41,7 @@ export const router = async () => {
     { path: "/createPost", view: CreatePostPage },
     { path: "/location", view: LocationPage },
     { path: "/chatList/:productId", view: ChatRoomListPage },
-    { path: "/chat/:productId", view: ChatRoomPage },
+    { path: "/chat/:roomId", view: ChatRoomPage },
   ];
 
   const potentialMatches = routes.map((route) => {


### PR DESCRIPTION
## 개요
  - product detail 판매자가 채팅리스트를 볼 수 있는 chatList 페이지를 mock api를 이용하여 구현하였습니다.

## 변경사항
  - chatList 페이지 에서 mock api를 이용해 채팅 리스트 display
  - productDetail에서 구매자일시 문의하기를 누르면 채팅방 정보를 가져오는 api를 호출하여  반환하는 roomkey 값을 이용해 `/chat/:roomKey` 로 이동합니다.
  - productDetail에서 판매자일시 채팅목록을 누르면 `/chatList/:productId` 로 이동합니다.
  - chatList 에서 채팅창 클릭시 `/chat/:roomKey`로 이동합니다.
  - chatList에서 뒤로가기 클릭시 해당 상품의 productDetail로 redirect됩니다 

## 참고사항

## 추가 구현 필요사항
  - chat 에서 뒤로가기 클릭시 productDetail 혹은 menu로 리다이렉트를 해야합니다.

## 스크린샷
