### PR TITLE
[Refactor] Category API 디렉토리이동 과 Frontend Category 번호가아니라 이름으로 표시 

### DIFF
--- a/backend/src/model/Category/AbstractCategoryStore.js
+++ b/backend/src/model/Category/AbstractCategoryStore.js
@@ -1,4 +1,5 @@
 export default class AbstractCategoryStore {
   addCategory(id, name) {}
+  getCategory(id) {}
   getCategories() {}
 }

--- a/backend/src/model/Category/Store/MySQLCategoryStore.js
+++ b/backend/src/model/Category/Store/MySQLCategoryStore.js
@@ -1,6 +1,7 @@
 import AbstractCategoryStore from "../AbstractCategoryStore.js";
 import mysqlConnection from "../../../config/mysql.js";
 import Category from "../Category.js";
+import { compile } from "morgan";
 
 export default class MySQLCategoryStore extends AbstractCategoryStore {
   async getCategories() {
@@ -9,6 +10,24 @@ export default class MySQLCategoryStore extends AbstractCategoryStore {
       const result = await mysqlConnection.promise().query(query);
       const rows = result[0];
       return rows.map((row) => new Category(row.id, row.name));
+    } catch (err) {
+      console.log(err);
+      throw err;
+    }
+  }
+
+  async getCategory(id) {
+    const query = "SELECT id, name FROM category WHERE id = ?";
+    const params = [id];
+    try {
+      const result = await mysqlConnection.promise().query(query, params);
+      const rows = result[0];
+
+      if (rows.length > 0) {
+        return new Category(rows[0].id, rows[0].name);
+      } else {
+        return null;
+      }
     } catch (err) {
       throw err;
     }

--- a/backend/src/model/Product/Store/MySQLProductStore.js
+++ b/backend/src/model/Product/Store/MySQLProductStore.js
@@ -144,8 +144,8 @@ export default class MySQLProductStore extends AbstractProductStore {
       const rows = retrieveQueryResult[0];
       if (rows.length >= 1) {
         const row = rows[0];
+        await this._addCountOfViewProduct(row.id, row.countOfView);
 
-        await this._addCountOfViewProduct(row.countOfView, row.id);
         const images = await this._getProductImages(row.id);
         return new Product({
           id: row.id,
@@ -173,10 +173,13 @@ export default class MySQLProductStore extends AbstractProductStore {
   }
   async _addCountOfViewProduct(id, previsousCount) {
     const updateCountOfViewQuery = `
-    UPDATE product SET countOfView= ? WHERE id=?;
+    UPDATE product SET countOfView=? WHERE id=?;
     `;
     const params = [previsousCount + 1, id];
-    await mysqlConnection.promise().query(updateCountOfViewQuery, params);
+    const result = await mysqlConnection
+      .promise()
+      .query(updateCountOfViewQuery, params);
+    return result[0].affectedRows.length > 0;
   }
 
   async _getProductImages(id) {

--- a/backend/src/routes/api/category/index.js
+++ b/backend/src/routes/api/category/index.js
@@ -1,0 +1,42 @@
+import express from "express";
+import CategoryStore from "../../../model/Category/Store/MySQLCategoryStore.js";
+import {
+  SUCCESS_STATUS,
+  NOT_FOUND_STATUS,
+  INTERNAL_SERVER_ERROR_STATUS,
+} from "../../../util/HttpStatus.js";
+
+const categoryStore = new CategoryStore();
+const router = express.Router();
+
+router.get("/", async (req, res) => {
+  try {
+    const categories = await categoryStore.getCategories();
+    return res.status(SUCCESS_STATUS).json({
+      success: true,
+      categories,
+    });
+  } catch (err) {
+    return res
+      .status(INTERNAL_SERVER_ERROR_STATUS)
+      .json({ error: "unexpect error occured" });
+  }
+});
+
+router.get("/:id", async (req, res) => {
+  const { id } = req.params;
+  try {
+    const category = await categoryStore.getCategory(id);
+    if (category) {
+      res.status(SUCCESS_STATUS).json({ success: true, category });
+    } else {
+      res.status(NOT_FOUND_STATUS).json({ success: false });
+    }
+  } catch (err) {
+    return res
+      .status(INTERNAL_SERVER_ERROR_STATUS)
+      .json({ error: "unexpect error occured" });
+  }
+});
+
+export default router;

--- a/backend/src/routes/api/index.js
+++ b/backend/src/routes/api/index.js
@@ -3,11 +3,13 @@ import express from "express";
 import authRouter from "./auth/index.js";
 import accountRouter from "./account/index.js";
 import productRouter from "./product/index.js";
+import categoryRouter from "./category/index.js";
 
 const router = express.Router();
 
 router.use("/auth", authRouter);
 router.use("/account", accountRouter);
 router.use("/product", productRouter);
+router.use("/category", categoryRouter);
 
 export default router;

--- a/backend/src/routes/api/product/index.js
+++ b/backend/src/routes/api/product/index.js
@@ -6,7 +6,7 @@ import { upload } from "../../../app.js";
 import { ProductStatus } from "../../../model/Product/ProductStatus.js";
 
 import ProductStore from "../../../model/Product/Store/MySQLProductStore.js";
-import CategoryStore from "../../../model/Category/Store/MySQLCategoryStore.js";
+
 import Product from "../../../model/Product/Product.js";
 import {
   SUCCESS_STATUS,
@@ -17,9 +17,7 @@ import {
 } from "../../../util/HttpStatus.js";
 
 const router = express.Router();
-
-export const productStore = new ProductStore();
-export const categoryStore = new CategoryStore();
+const productStore = new ProductStore();
 
 router.get("/detail", async (req, res) => {
   const { id } = req.query;
@@ -31,19 +29,6 @@ router.get("/detail", async (req, res) => {
       .json({ success: false, error: "상품을 찾을 수 없습니다." });
   } else {
     return res.status(SUCCESS_STATUS).json({ success: true, product });
-  }
-});
-
-router.get("/category", async (req, res) => {
-  try {
-    const categories = await categoryStore.getCategories();
-    return res.status(SUCCESS_STATUS).json({
-      category: categories,
-    });
-  } catch (err) {
-    return res
-      .status(INTERNAL_SERVER_ERROR_STATUS)
-      .json({ error: "unexpect error occured" });
   }
 });
 

--- a/frontend/src/api/product.js
+++ b/frontend/src/api/product.js
@@ -84,7 +84,7 @@ export const createProductAsync = ({
 
 export const getCategoriesAsync = () =>
   new Promise((resolve, reject) => {
-    const request = fetch("/api/product/category", {
+    const request = fetch("/api/category", {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -92,6 +92,19 @@ export const getCategoriesAsync = () =>
     }).then((response) => response.json());
     resolve(request);
   });
+
+export const getCategoryAsync = (id) => {
+  return new Promise((resolve, reject) => {
+    const request = fetch(`/api/category/${id}`, {
+      method: "GET",
+
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }).then((response) => response.json());
+    resolve(request);
+  });
+};
 
 export const updateProductStatusAsync = (productId, status) => {
   return new Promise((resolve, _) => {

--- a/frontend/src/page/CreatePostPage/Controller.js
+++ b/frontend/src/page/CreatePostPage/Controller.js
@@ -1,6 +1,10 @@
 import { categoryItems } from "@/util/category";
 
-import { createProductAsync, uploadProductImagesAsync } from "@/api/product";
+import {
+  createProductAsync,
+  getCategoriesAsync,
+  uploadProductImagesAsync,
+} from "@/api/product";
 import { navigateTo } from "@/router";
 import { getProfileAsync } from "@/api/user";
 
@@ -31,6 +35,12 @@ export default class Controller {
   }
 
   fetchData() {
+    getCategoriesAsync().then(({ success, categories }) => {
+      if (success) {
+        this.store.categories = categories;
+        this.render();
+      }
+    });
     getProfileAsync().then(({ isAuth, account }) => {
       if (isAuth) {
         const { locations } = account;
@@ -144,10 +154,11 @@ export default class Controller {
   }
 
   render() {
-    const { images, category, content, title, location, cost } = this.store;
+    const { images, category, content, title, location, cost, categories } =
+      this.store;
 
     if (this.isShowCategorySelectView) {
-      this.categorySelectView.show();
+      this.categorySelectView.show(categories);
       this.createPostFormView.hide();
       this.createPostHeaderView.hide();
     } else {

--- a/frontend/src/page/CreatePostPage/Store.js
+++ b/frontend/src/page/CreatePostPage/Store.js
@@ -6,5 +6,6 @@ export default class Store {
     this.title = "";
     this.content = "";
     this.location = "";
+    this.categories = [];
   }
 }

--- a/frontend/src/page/CreatePostPage/views/CategorySelectView.js
+++ b/frontend/src/page/CreatePostPage/views/CategorySelectView.js
@@ -35,14 +35,14 @@ export default class CategorySelectView extends View {
     this.emit("@back");
   }
 
-  show() {
-    this.element.innerHTML = this.template.getCategorySeletView();
+  show(categories = []) {
+    this.element.innerHTML = this.template.getCategorySeletView(categories);
     super.show();
   }
 }
 
 class Template {
-  getCategorySeletView() {
+  getCategorySeletView(categories) {
     return /* html */ `
     <header class="header">
         <div class="header--left">
@@ -52,18 +52,18 @@ class Template {
             <span class="header--center--title"> 카테고리 </span>
         </h1>
     </header>
-    <div class="category-list">${this._getCategoryItems()}</div>
+    <div class="category-list">${this._getCategoryItems(categories)}</div>
     `;
   }
 
-  _getCategoryItems() {
-    return categoryItems
-      .map((categoryItem) => this._getCategoryItem(categoryItem))
+  _getCategoryItems(categories) {
+    return categories
+      .map((category) => this._getCategoryItem(category))
       .join("");
   }
 
-  _getCategoryItem(categoryItem) {
-    const { id, name } = categoryItem;
+  _getCategoryItem(category) {
+    const { id, name } = category;
     return `<div class="category-list--item" data-id=${id}>${name}</div>`;
   }
 }

--- a/frontend/src/page/HomePage/Controller.js
+++ b/frontend/src/page/HomePage/Controller.js
@@ -99,8 +99,8 @@ export default class Controller {
 
   showCategory() {
     this.isShowCategoryView = true;
-    getCategoriesAsync().then(({ category }) => {
-      this.store.categoryList = category;
+    getCategoriesAsync().then(({ categories }) => {
+      this.store.categoryList = categories;
       this.render();
     });
   }

--- a/frontend/src/page/LocationPage/views/AddLocationModalView.js
+++ b/frontend/src/page/LocationPage/views/AddLocationModalView.js
@@ -19,6 +19,11 @@ export default class AddLocationModalView extends View {
     on(this.acceptBtnElement, "click", (e) =>
       this.handleAcceptButtonClickEvent()
     );
+    on(this.locationInputElement, "keydown", (e) => {
+      if (e.keyCode == 13) {
+        this.handleAcceptButtonClickEvent();
+      }
+    });
   }
 
   handleCancelButtonClickEvent() {

--- a/frontend/src/page/LoginPage/Controller.js
+++ b/frontend/src/page/LoginPage/Controller.js
@@ -13,10 +13,10 @@ export default class Controller {
     this.init();
     this.error = {};
     this.subscribeViewEvents();
-    this.render();
   }
+
   init() {
-    getProfileAsync().then(({ account, isAuth }) => {
+    getProfileAsync().then(({ isAuth }) => {
       if (isAuth) {
         navigateTo("/profile");
       }

--- a/frontend/src/page/ProductDetailPage/Controller.js
+++ b/frontend/src/page/ProductDetailPage/Controller.js
@@ -1,7 +1,11 @@
 import { navigateTo } from "@/router";
 
 import { getChatRoomAsync } from "@/api/chat";
-import { getProductDetailAsync, updateProductStatusAsync } from "@/api/product";
+import {
+  getCategoryAsync,
+  getProductDetailAsync,
+  updateProductStatusAsync,
+} from "@/api/product";
 import {
   getProfileAsync,
   removeInterestProductAsync,
@@ -55,16 +59,20 @@ export default class Controller {
     this.productDetailHeaderView.on("@modifyPost", () => {
       navigateTo(`/product-edit/${this.store.productId}`);
     });
+
     this.productDetailHeaderView.on("@deletePost", () => {
       navigateTo(`/product-edit/${this.store.productId}`);
     });
 
     this.productDetailView.on("@change-status", (e) => {
       const status = e.detail.value;
-
-      updateProductStatusAsync(this.store.productId, status).then((result) => {
-        this.fetchProductDetailData();
-      });
+      updateProductStatusAsync(this.store.productId, status).then(
+        ({ success }) => {
+          if (success) {
+            this.fetchProductDetailData();
+          }
+        }
+      );
     });
   }
 
@@ -84,6 +92,17 @@ export default class Controller {
     if (this.productId === undefined) {
       navigateTo("/");
     }
+
+    getCategoryAsync(this.store.productId).then(({ success, category }) => {
+      if (success) {
+        this.store.categoryName = category.name;
+      } else {
+        this.store.categoryName = category.id;
+      }
+
+      this.render();
+    });
+
     getProfileAsync().then(({ isAuth, account }) => {
       this.store.user = account;
       this.fetchProductDetailData();
@@ -102,10 +121,10 @@ export default class Controller {
   }
 
   render() {
-    const { productDetail, user } = this.store;
+    const { productDetail, user, categoryName } = this.store;
     this.productDetailHeaderView.show(user, productDetail);
     this.productImageListView.show(productDetail.images);
-    this.productDetailView.show(user, productDetail);
+    this.productDetailView.show(user, productDetail, categoryName);
     this.productDetailFooterView.show(user, productDetail);
   }
 }

--- a/frontend/src/page/ProductDetailPage/Store.js
+++ b/frontend/src/page/ProductDetailPage/Store.js
@@ -1,6 +1,7 @@
 export default class Store {
   constructor({ productId }) {
     this.user = {};
+    this.categoryName = "";
     this.productId = productId;
     this.productDetail = {};
   }

--- a/frontend/src/page/ProductDetailPage/views/ProductDetailView.js
+++ b/frontend/src/page/ProductDetailPage/views/ProductDetailView.js
@@ -50,14 +50,18 @@ export default class ProductDetailView extends View {
     menu.setAttribute("aria-expanded", expand);
   }
 
-  show(user, productDetail) {
-    this.element.innerHTML = this.template.getDetail(user, productDetail);
+  show(user, productDetail, categoryName) {
+    this.element.innerHTML = this.template.getDetail(
+      user,
+      productDetail,
+      categoryName
+    );
     super.show();
   }
 }
 
 class Template {
-  getDetail(user, productDetail) {
+  getDetail(user, productDetail, categoryName) {
     const {
       status,
       title,
@@ -75,7 +79,7 @@ class Template {
       
       <div class="post-main--title">${title}</div>
       <div class="post-main--sub-title">
-          <p class="category-name-label">${category}</p>
+          <p class="category-name-label">${categoryName}</p>
           <p class="create-time-label">${timeForToday(createdAt)}</p> 
       </div>
       <div class="post-main--content">


### PR DESCRIPTION
## 개요

PR 제목 그대로 Category API들이 product API들과 합쳐져있었는데 개별 카테고리 정보 조회 API를 추가하면서 따로 디렉토리를 분리했습니다.

- 추가로 조회수 올라가지 안던 버그도 같이 수정했습니다. (인자값 순서떄문에)

그외 큰 변경은 없습니다.
