### PR TITLE
Add: 채팅상세화면에서 각 상화에 맞는 Back 화면 네비게이션 개선

### DIFF
--- a/frontend/src/page/ChatRoomListPage/Controller.js
+++ b/frontend/src/page/ChatRoomListPage/Controller.js
@@ -1,10 +1,12 @@
 import { getChatRoomsByProductAsync } from "@/api/chat";
+import { navigateTo } from "@/router";
 
 export default class Controller {
   constructor(store, { chatRoomListHeaderView, chatRoomListContentView }) {
     this.chatRoomListHeaderView = chatRoomListHeaderView;
     this.chatRoomListContentView = chatRoomListContentView;
     this.store = store;
+    this.subscribeViewEvents();
     this.init();
   }
 
@@ -15,6 +17,15 @@ export default class Controller {
         this.render();
       }
     );
+  }
+
+  subscribeViewEvents() {
+    this.chatRoomListContentView.on("@move-to-chat", (e) => {
+      const roomId = e.detail.value;
+      navigateTo("/chat/" + roomId, {
+        previous: "/chatList/" + this.store.productId,
+      });
+    });
   }
 
   render() {

--- a/frontend/src/page/ChatRoomListPage/Store.js
+++ b/frontend/src/page/ChatRoomListPage/Store.js
@@ -2,14 +2,5 @@ export default class Store {
   constructor(productId) {
     this.productId = productId;
     this.chatRoomListItems = [];
-    /*
-        this.roomKey = undefined;
-        this.targetUser = undefined;
-        this.productId = undefined;
-        this.unreadCount = 0;
-        this.productThumbnail = undefined;
-        this.chatLogs = [];
-        this.totalMessageCount = 0;
-    */
   }
 }

--- a/frontend/src/page/ChatRoomListPage/views/ChatRoomListContentView.js
+++ b/frontend/src/page/ChatRoomListPage/views/ChatRoomListContentView.js
@@ -20,7 +20,7 @@ export default class ChatRoomListContentView extends View {
 
   handleChatRoomClick = (event) => {
     const roomId = event.target.dataset.roomId;
-    navigateTo(`/chat/${roomId}`);
+    this.emit("@move-to-chat", { value: roomId });
   };
 
   show(chatRoomListItems = []) {

--- a/frontend/src/page/ChatRoomListPage/views/chatRoomListHeaderView.js
+++ b/frontend/src/page/ChatRoomListPage/views/chatRoomListHeaderView.js
@@ -2,6 +2,7 @@ import View from "@/page/View";
 import { qs } from "@/helper/selectHelpers.js";
 
 import chevronLeftSvg from "@/public/svg/chevron-left.svg";
+import { delegate } from "@/helper/eventHelpers";
 
 export default class ChatRoomListHeaderView extends View {
   constructor(element = qs(".header"), template = new Template()) {

--- a/frontend/src/page/ChatRoomPage/Controller.js
+++ b/frontend/src/page/ChatRoomPage/Controller.js
@@ -1,7 +1,7 @@
 import { getChatRoomAsync, getChatsAsync } from "@/api/chat.js";
 import { getProductDetailAsync } from "@/api/product";
 import { getProfileAsync } from "@/api/user";
-import { navigateTo } from "@/router";
+import { navigateTo, router } from "@/router";
 import { io } from "socket.io-client";
 
 export default class Controller {
@@ -57,8 +57,7 @@ export default class Controller {
     });
 
     this.chatRoomHeaderView.on("@back", () => {
-      const { id } = this.store.product;
-      navigateTo("/product/" + id);
+      navigateTo(history.state.previous);
     });
 
     this.chatRoomInputContainerView.on("@send-message", (event) => {

--- a/frontend/src/page/MenuPage/Controller.js
+++ b/frontend/src/page/MenuPage/Controller.js
@@ -43,8 +43,7 @@ export default class Controller {
   }
 
   moveToChatRoom(roomId) {
-    console.log(roomId);
-    navigateTo("/chat/" + roomId);
+    navigateTo("/chat/" + roomId, { previous: "/menu" });
   }
 
   changeInterest(productId, isInterested) {

--- a/frontend/src/page/ProductDetailPage/Controller.js
+++ b/frontend/src/page/ProductDetailPage/Controller.js
@@ -64,11 +64,15 @@ export default class Controller {
       const { productId } = this.store;
       attendChatRoomAsync(productId).then(({ success, roomId }) => {
         if (success) {
-          navigateTo("/chat/" + roomId);
+          navigateTo("/chat/" + roomId, { previous: "/product/" + productId });
         } else {
           console.error("채팅방 정보가져오는데 실패");
         }
       });
+    });
+
+    this.productDetailFooterView.on("@move-to-chatlist", (e) => {
+      navigateTo("/chatList/" + this.store.productId);
     });
   }
 

--- a/frontend/src/page/ProductDetailPage/views/ProductDetailFooterView.js
+++ b/frontend/src/page/ProductDetailPage/views/ProductDetailFooterView.js
@@ -20,6 +20,13 @@ export default class ProductDetailFooterView extends View {
     delegate(this.element, "click", "#attend-chat-btn", (e) => {
       this.handleClickGetChatRoom(e);
     });
+
+    delegate(this.element, "click", "#move-to-chat-list-btn", (e) => {
+      this.handleClickChatListButton(e);
+    });
+  }
+  handleClickChatListButton() {
+    this.emit("@move-to-chatlist");
   }
 
   handleClickInterestEvent(event) {
@@ -54,9 +61,9 @@ class Template {
         ${
           user?.username === author
             ? `
-                <a href="/chatList/${id}" data-link>
-                    <div class="move-btn">채팅 목록 보기</div> 
-                </a>`
+                <div>
+                    <div id="move-to-chat-list-btn" class="move-btn">채팅 목록 보기</div> 
+                </div>`
             : `
                 <div>
                     <div class="move-btn" id="attend-chat-btn">문의하기</div> 

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -25,8 +25,8 @@ const getParams = (match) => {
   );
 };
 
-export const navigateTo = (url) => {
-  history.pushState(null, null, url);
+export const navigateTo = (url, data = null) => {
+  history.pushState(data, null, url);
   router();
 };
 


### PR DESCRIPTION
## 개요

채팅 화면에서 뒤로가기 버튼을 눌렀을 때 상황에 맞는 이전 화면으로 돌아가는 기능을 추가했습니다.

SPA 에서 History API 를 이용할 경우, 수동으로 뒤로가는 기능을 처리해줘야했습니다. 


## 변경사항

3가지 화면에서 `/chat/[chatroom id]`로 네비게이션을 하게 됩니다. 

각 3가지 경우에서 채팅으로 이동할 때, ` navigateTo("/chat/[room id]", {previous: "현재 경로"})`와 같이  이전 페이지 정보를 담아 놓고
이동을 할 경우,

채팅 화면에서 상황에 맞게 previous 값을 가지고 있기 때문에 뒤로 가기버튼을 눌렀을때 previous 로 이동하면 됩니다.

## 참고사항

History API 를 충분히 학습할 시간이 없어서 완벽하지 않은  방법일 수 있습니다. 더나은 방법이 있다면 피드백 부탁드립니다.

## 추가 구현 필요사항

## 스크린샷
