### PR TITLE
글쓰기에서 이미지 중간 수정할 수 있는 기능 추가

### DIFF
--- a/frontend/src/common/views/ProductListView.js
+++ b/frontend/src/common/views/ProductListView.js
@@ -33,14 +33,25 @@ export default class ProductListView extends View {
     delegate(this.element, "click", "#interest-btn", (e) =>
       this.handleClickInterestEvent(e)
     );
+
+    delegate(this.element, "click", "#setting-btn", (e) =>
+      this.handleClickSettingEvent(e)
+    );
   }
 
   handleClickInterestEvent(event) {
     const target = event.target;
-    const id = target.dataset.id;
+    const { id } = target.dataset;
     const currentInterestStatus = Array.from(target.classList).includes("on");
     this.emit("@interest", {
       value: { id, isInterested: !currentInterestStatus },
+    });
+  }
+
+  handleClickSettingEvent(event) {
+    const { id } = event.target.dataset;
+    this.emit("@setting", {
+      value: { id },
     });
   }
 
@@ -100,7 +111,7 @@ class Template {
                     ? this._getInterestBtn(isInterested, id)
                     : ""
                 }
-                ${option.showSettingBtn ? this._getSettingBtn() : ""}
+                ${option.showSettingBtn ? this._getSettingBtn(id) : ""}
               </div>
               <div>
                 <span class="location">${location}</span>
@@ -145,8 +156,8 @@ class Template {
     `;
   }
 
-  _getSettingBtn() {
-    return `<div id="setting-btn" class="content--product--info--top--menu">
+  _getSettingBtn(id) {
+    return `<div id="setting-btn" class="content--product--info--top--menu" data-id=${id}>
       ${moreVerticalSVG}
     </div>`;
   }

--- a/frontend/src/page/CreatePostPage/Controller.js
+++ b/frontend/src/page/CreatePostPage/Controller.js
@@ -41,6 +41,7 @@ export default class Controller {
         this.render();
       }
     });
+
     getProfileAsync().then(({ isAuth, account }) => {
       if (isAuth) {
         const { locations } = account;
@@ -92,7 +93,16 @@ export default class Controller {
     });
 
     this.imageUploadView.on("@image-upload", (e) => {
-      this.uploadImagesFromFileSystem(e.detail.value);
+      const files = e.detail.value;
+      this.uploadImagesFromFileSystem(files);
+    });
+
+    this.imageUploadView.on("@image-delete", (e) => {
+      const fileKey = Number(e.detail.value);
+      this.store.images = [...this.store.images].filter(
+        (_, idx) => idx !== fileKey
+      );
+      this.render();
     });
 
     this.createPostHeaderView.on("@create-post", (e) => this.createPost());

--- a/frontend/src/page/CreatePostPage/views/CategorySelectView.js
+++ b/frontend/src/page/CreatePostPage/views/CategorySelectView.js
@@ -2,9 +2,6 @@ import { qs } from "@/helper/selectHelpers";
 import { delegate } from "@/helper/eventHelpers";
 
 import View from "@/page/View";
-
-import { categoryItems } from "@/util/category";
-
 import chevronLeftSVG from "@/public/svg/chevron-left.svg";
 
 import "@/public/css/categorySelect.css";

--- a/frontend/src/page/CreatePostPage/views/ImageUploadView.js
+++ b/frontend/src/page/CreatePostPage/views/ImageUploadView.js
@@ -1,6 +1,8 @@
 import View from "@/page/View";
 import { qs } from "@/helper/selectHelpers";
-import { on } from "@/helper/eventHelpers";
+import { delegate, on } from "@/helper/eventHelpers";
+
+import closeSVG from "@/public/svg/close-white.svg";
 
 export default class ImageUploadView extends View {
   constructor(
@@ -17,6 +19,14 @@ export default class ImageUploadView extends View {
 
   bindingEvent() {
     on(this.imgInputElement, "change", (e) => this.handleImageUploadEvent(e));
+    delegate(this.element, "click", ".img-box--delete-btn", (e) => {
+      const { key } = e.target.dataset;
+      this.handleTempImageDeleteClickEvent(key);
+    });
+  }
+
+  handleTempImageDeleteClickEvent(imageKey) {
+    this.emit("@image-delete", { value: imageKey });
   }
 
   handleImageUploadEvent(e) {
@@ -27,33 +37,36 @@ export default class ImageUploadView extends View {
   }
 
   renderImagesAsync(files) {
-    const imagePaths = Object.keys(files).map((i) => {
+    const imageFiles = Object.keys(files).map((i) => {
       const file = files[i];
       const url = URL.createObjectURL(file);
-      return url;
+      return { key: i, url };
     });
 
-    this.imgContainerElement.innerHTML = this.template.getImageList(imagePaths);
+    this.imgContainerElement.innerHTML = this.template.getImageList(imageFiles);
   }
 
   show(images) {
     const countOfImage = Object.keys(images).length;
-    if (countOfImage > 0) {
-      this.renderImagesAsync(images);
-    }
+    this.renderImagesAsync(images);
+
     this.imgCountLabelElement.innerText = countOfImage;
     super.show();
   }
 }
 
 class Template {
-  getImageList(images) {
-    return images.map((image) => this._getImage(image)).join("");
+  getImageList(imageFiles = []) {
+    return imageFiles.map((imageFile) => this._getImage(imageFile)).join("");
   }
-  _getImage(image) {
+  _getImage(imageFile) {
+    const { key, url } = imageFile;
     return /* html */ `
-    <div class="img-box" >
-      <img src="${image}"/>
+    <div class="img-box">
+      <img class="img-box--img" src="${url}"/>
+      <div class="img-box--delete-btn" data-key=${key}>
+        ${closeSVG}
+      </div>
     </div>`;
   }
 }

--- a/frontend/src/page/LocationPage/views/AddLocationModalView.js
+++ b/frontend/src/page/LocationPage/views/AddLocationModalView.js
@@ -36,12 +36,12 @@ export default class AddLocationModalView extends View {
   }
 
   show() {
-    this.blurBgElement.style.display = "block";
+    this.blurBgElement.style.visibility = "visible";
     super.show();
   }
 
   hide() {
-    this.blurBgElement.style.display = "none";
+    this.blurBgElement.style.visibility = "hidden";
     super.hide();
   }
 }

--- a/frontend/src/page/LocationPage/views/DeleteLocationModalView.js
+++ b/frontend/src/page/LocationPage/views/DeleteLocationModalView.js
@@ -32,13 +32,13 @@ export default class DeleteLocationModalView extends View {
   }
 
   show(location) {
-    this.blurBgElement.style.display = "block";
+    this.blurBgElement.style.visibility = "visible";
     this.locationNameElement.innerText = '"' + location + '"';
     super.show();
   }
 
   hide() {
-    this.blurBgElement.style.display = "none";
+    this.blurBgElement.style.visibility = "hidden";
     super.hide();
   }
 }

--- a/frontend/src/page/MenuPage/Controller.js
+++ b/frontend/src/page/MenuPage/Controller.js
@@ -35,10 +35,17 @@ export default class Controller {
     this.chatRoomListView.on("@move-to-chat", (e) =>
       this.moveToChatRoom(e.detail.value)
     );
+
     this.tabView.on("@change-tab", (e) => this.changeTab(e.detail.value));
+
     this.interestProductListView.on("@interest", (e) => {
       const { id, isInterested } = e.detail.value;
       this.changeInterest(id, isInterested);
+    });
+
+    this.salingProductListView.on("@setting", (e) => {
+      const { id } = e.detail.value;
+      console.log(id);
     });
   }
 

--- a/frontend/src/page/MenuPage/index.js
+++ b/frontend/src/page/MenuPage/index.js
@@ -39,6 +39,11 @@ export default class MenuPage extends AbstractPage {
             <section id="interest-list-window"></section>
         </div>
     </div>
+    <div id="modal-blur-bg" class="blur-bg"></div>
+    <div id="setting-menu-modal" class="modal">
+      <div id="setting-edit-btn">수정</div>
+      <div id="setting-delete-btn">삭제</div>  
+    </div>
     `;
   }
 

--- a/frontend/src/page/ProductDetailPage/views/ProductDetailModalView.js
+++ b/frontend/src/page/ProductDetailPage/views/ProductDetailModalView.js
@@ -20,11 +20,11 @@ export default class ProductDetailModalView extends View {
   }
 
   show() {
-    this.blurBgElement.style.display = "block";
+    this.blurBgElement.style.visibility = "visible";
     super.show();
   }
   hide() {
-    this.blurBgElement.style.display = "none";
+    this.blurBgElement.style.visibility = "hidden";
     super.hide();
   }
 }

--- a/frontend/src/public/css/categorySelect.css
+++ b/frontend/src/public/css/categorySelect.css
@@ -15,10 +15,11 @@
 }
 
 .category-list--item {
+  cursor: pointer;
   font-size: 14px;
   padding-top: 16px;
   padding-bottom: 16px;
   width: 100%;
   text-align: center;
-  border-bottom: 1px solid black;
+  border-bottom: 1px solid #c0c0c0;
 }

--- a/frontend/src/public/css/common/modal.css
+++ b/frontend/src/public/css/common/modal.css
@@ -1,5 +1,5 @@
 .blur-bg {
-  display: none;
+  visibility: hidden;
   position: absolute;
   left: 0;
   top: 0;
@@ -10,12 +10,11 @@
 }
 
 .modal {
-  display: none;
+  visibility: hidden;
   padding: 16px 20px;
+  position: absolute;
   display: flex;
   flex-direction: column;
-  justify-content: space-around;
-  position: absolute;
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);

--- a/frontend/src/public/css/createPost.css
+++ b/frontend/src/public/css/createPost.css
@@ -50,20 +50,44 @@
 }
 
 .img-container {
-  height: 80px;
+  display: flex;
+  align-items: center;
+  height: 100px;
   flex-grow: 1;
   display: flex;
   overflow-x: auto;
 }
 
 .img-box {
-  margin-right: 2px;
+  position: relative;
+  margin-right: 10px;
 }
-.img-box > img {
+
+.img-box:hover {
+  border-radius: 8px;
+}
+
+.img-box--img {
   width: 76px;
   height: 76px;
   border-radius: 8px;
-  border: 1px solid #f6f6f6;
+  border: 1px solid var(--primary1-color);
+}
+
+.img-box:hover .img-box--delete-btn {
+  display: block;
+}
+
+.img-box--delete-btn {
+  display: none;
+  z-index: 99;
+  border-radius: 5px;
+  background-color: var(--primary1-color);
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  right: -8px;
+  top: -8px;
 }
 
 .posting-main--text-input {
@@ -87,8 +111,6 @@
 }
 
 .posting-main--category-btn {
-  padding-top: 5px;
-  padding-bottom: 5px;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -101,7 +123,7 @@
   pointer-events: none;
 }
 
-.posting-main--category-btn .right-arrow-icon svg {
+.posting-main--category-btn .posting-main--category-btn .right-arrow-icon svg {
   width: 20px;
   height: 20px;
 }
@@ -130,8 +152,8 @@
 .split-line {
   width: 100%;
   height: 1px;
-  margin-top: 24px;
-  margin-bottom: 24px;
+  margin-top: 12px;
+  margin-bottom: 12px;
   border: 0.5px solid #c0c0c0;
 }
 


### PR DESCRIPTION
## 개요
글쓰기 화면에서 한번 등록된 이미지들을 수정할 수 없었는데 이번 PR해당 기능을 추가했습니다.

## 변경사항

프론트엔드 수준에서 변경만 있었습니다.

각 이미지에 hover 의해 삭제 버튼이 생기고 버튼을 누룰시 해당 페이지의 상태(store)를 수정하고 다시 렌더링하는 방식입니다.

## 참고사항
## 추가 구현 필요사항
## 스크린샷
<img width="384" alt="스크린샷 2021-07-22 오후 8 23 02" src="https://user-images.githubusercontent.com/20085849/126631686-04d851bc-a03c-4b78-ac04-9dbea2299cbe.png">

