### PR TITLE
메뉴 탭화면에서 자기가 판매중인 상품을 제거할 수 있는 모달 구현

### DIFF
--- a/backend/src/model/Product/Store/MySQLProductStore.js
+++ b/backend/src/model/Product/Store/MySQLProductStore.js
@@ -74,7 +74,7 @@ export default class MySQLProductStore extends AbstractProductStore {
     p.content AS content, p.cost AS cost, p.status AS status, p.location AS location,
     p.thumbnail AS thumbnail, p.createdAt AS createdAt, p.updatedAt AS updatedAt, p.countOfView AS countOfView,
     CASE WHEN my_ip.username IS NULL THEN FALSE ELSE TRUE END as isInterested,
-    COUNT(ip.username) as countOfInterest, COUNT(cr.roomId) as countOfChat
+    COUNT(ip.username) as countOfInterest, COUNT(DISTINCT cr.roomId) as countOfChat
     FROM product AS p 
     LEFT JOIN (SELECT username, id FROM interest_product WHERE username = ?) AS my_ip ON my_ip.id = p.id
     LEFT JOIN interest_product AS ip ON ip.id = p.id 

--- a/backend/src/routes/api/account/index.js
+++ b/backend/src/routes/api/account/index.js
@@ -17,14 +17,16 @@ const chatStore = new ChatStore();
 
 const router = express.Router();
 
-router.use("", authMiddleware);
-
 router.get("/me", async (req, res) => {
-  const account = await accountStore.getAccount(req.session.username);
-  return res.json({ isAuth: true, account });
+  if (req.session.username) {
+    const account = await accountStore.getAccount(req.session.username);
+    return res.json({ isAuth: true, account });
+  } else {
+    return res.json({ isAuth: false });
+  }
 });
 
-router.post("/me/location", async (req, res) => {
+router.post("/me/location", authMiddleware, async (req, res) => {
   const { location } = req.body;
 
   const username = req.session.username;
@@ -48,7 +50,7 @@ router.post("/me/location", async (req, res) => {
   }
 });
 
-router.delete("/me/location", async (req, res) => {
+router.delete("/me/location", authMiddleware, async (req, res) => {
   const { location } = req.query;
   const username = req.session.username;
   const account = await accountStore.getAccount(username);
@@ -81,7 +83,7 @@ router.delete("/me/location", async (req, res) => {
   }
 });
 
-router.get("/me/interest", async (req, res) => {
+router.get("/me/interest", authMiddleware, async (req, res) => {
   const username = req.session.username;
   const products = await productStore.getInterestProducts(username);
   return res.status(SUCCESS_STATUS).json({
@@ -90,7 +92,7 @@ router.get("/me/interest", async (req, res) => {
   });
 });
 
-router.post("/me/interest", async (req, res) => {
+router.post("/me/interest", authMiddleware, async (req, res) => {
   const username = req.session.username;
   const { productId } = req.query;
   if (!productId) {
@@ -119,7 +121,7 @@ router.post("/me/interest", async (req, res) => {
   }
 });
 
-router.delete("/me/interest", async (req, res) => {
+router.delete("/me/interest", authMiddleware, async (req, res) => {
   const username = req.session.username;
   const { productId } = req.query;
 
@@ -141,7 +143,7 @@ router.delete("/me/interest", async (req, res) => {
   }
 });
 
-router.get("/me/product", async (req, res) => {
+router.get("/me/product", authMiddleware, async (req, res) => {
   const username = req.session.username;
   const products = await productStore.getOwnProducts(username);
   return res.status(SUCCESS_STATUS).json({
@@ -150,7 +152,7 @@ router.get("/me/product", async (req, res) => {
   });
 });
 
-router.get("/me/chatroom", async (req, res) => {
+router.get("/me/chatroom", authMiddleware, async (req, res) => {
   const username = req.session.username;
   try {
     const chatRoomListItems = await chatStore.getChatRooms(username);

--- a/frontend/src/common/views/ModalView.js
+++ b/frontend/src/common/views/ModalView.js
@@ -1,0 +1,17 @@
+import View from "@/page/View";
+
+export default class ModalView extends View {
+  constructor(element) {
+    super(element);
+  }
+
+  show() {
+    this.element.style.visibility = "visible";
+    super.show();
+  }
+
+  hide() {
+    this.element.style.visibility = "hidden";
+    super.hide();
+  }
+}

--- a/frontend/src/page/LocationPage/Controller.js
+++ b/frontend/src/page/LocationPage/Controller.js
@@ -13,12 +13,15 @@ export default class Controller {
       deleteLocationModalView,
       addLocationModalView,
       locationCommentView,
+      modalBlurBGView,
     }
   ) {
     this.store = store;
 
     this.deleteLocationModalView = deleteLocationModalView;
     this.addLocationModalView = addLocationModalView;
+    this.modalBlurBGView = modalBlurBGView;
+
     this.locationListView = locationListView;
     this.locationCommentView = locationCommentView;
 
@@ -158,6 +161,12 @@ export default class Controller {
       this.deleteLocationModalView.show(targetLocation);
     } else {
       this.deleteLocationModalView.hide();
+    }
+
+    if (this.isShowAddLocationModal || this.isShowDeleteLocationModal) {
+      this.modalBlurBGView.show();
+    } else {
+      this.modalBlurBGView.hide();
     }
   }
 }

--- a/frontend/src/page/LocationPage/index.js
+++ b/frontend/src/page/LocationPage/index.js
@@ -10,6 +10,7 @@ import AddLocationModalView from "./views/AddLocationModalView";
 import DeleteLocationModalView from "./views/DeleteLocationModalView";
 import Store from "./Store";
 import LocationCommentView from "./views/LocationCommentView";
+import ModalBlurBGView from "./views/ModelBlurBGView";
 
 const tag = "[LocationPage]";
 
@@ -79,6 +80,7 @@ export default class LocationPage extends AbstractPage {
     const views = {
       deleteLocationModalView: new DeleteLocationModalView(),
       addLocationModalView: new AddLocationModalView(),
+      modalBlurBGView: new ModalBlurBGView(),
       locationListView: new LocationListView(),
       locationCommentView: new LocationCommentView(),
     };

--- a/frontend/src/page/LocationPage/views/AddLocationModalView.js
+++ b/frontend/src/page/LocationPage/views/AddLocationModalView.js
@@ -1,8 +1,8 @@
-import View from "@/page/View";
+import ModalView from "@/common/views/ModalView";
 import { qs } from "@/helper/selectHelpers";
 import { on } from "@/helper/eventHelpers";
 
-export default class AddLocationModalView extends View {
+export default class AddLocationModalView extends ModalView {
   constructor(element = qs("#location-edit-modal")) {
     super(element);
     this.cancelBtnElement = qs("#cancel-btn", this.element);

--- a/frontend/src/page/LocationPage/views/AddLocationModalView.js
+++ b/frontend/src/page/LocationPage/views/AddLocationModalView.js
@@ -8,7 +8,6 @@ export default class AddLocationModalView extends View {
     this.cancelBtnElement = qs("#cancel-btn", this.element);
     this.acceptBtnElement = qs("#accept-btn", this.element);
     this.locationInputElement = qs("#edit-location-input", this.element);
-    this.blurBgElement = qs("#modal-blur-bg");
     this.eventsBinding();
   }
 
@@ -33,15 +32,5 @@ export default class AddLocationModalView extends View {
   handleAcceptButtonClickEvent() {
     const location = this.locationInputElement.value;
     this.emit("@add-location", { value: location });
-  }
-
-  show() {
-    this.blurBgElement.style.visibility = "visible";
-    super.show();
-  }
-
-  hide() {
-    this.blurBgElement.style.visibility = "hidden";
-    super.hide();
   }
 }

--- a/frontend/src/page/LocationPage/views/DeleteLocationModalView.js
+++ b/frontend/src/page/LocationPage/views/DeleteLocationModalView.js
@@ -1,8 +1,8 @@
 import { qs } from "@/helper/selectHelpers";
 import { on } from "@/helper/eventHelpers";
-import View from "@/page/View";
+import ModalView from "@/common/views/ModalView";
 
-export default class DeleteLocationModalView extends View {
+export default class DeleteLocationModalView extends ModalView {
   constructor(element = qs("#location-delete-modal")) {
     super(element);
 
@@ -31,11 +31,7 @@ export default class DeleteLocationModalView extends View {
   }
 
   show(location) {
-    this.locationNameElement.innerText = '"' + location + '"';
     super.show();
-  }
-
-  hide() {
-    super.hide();
+    this.locationNameElement.innerText = '"' + location + '"';
   }
 }

--- a/frontend/src/page/LocationPage/views/DeleteLocationModalView.js
+++ b/frontend/src/page/LocationPage/views/DeleteLocationModalView.js
@@ -9,7 +9,6 @@ export default class DeleteLocationModalView extends View {
     this.locationNameElement = qs("#location-name", this.element);
     this.cancelBtnElement = qs("#cancel-btn", this.element);
     this.acceptBtnElement = qs("#accept-btn", this.element);
-    this.blurBgElement = qs("#modal-blur-bg");
 
     this.eventsBinding();
   }
@@ -32,13 +31,11 @@ export default class DeleteLocationModalView extends View {
   }
 
   show(location) {
-    this.blurBgElement.style.visibility = "visible";
     this.locationNameElement.innerText = '"' + location + '"';
     super.show();
   }
 
   hide() {
-    this.blurBgElement.style.visibility = "hidden";
     super.hide();
   }
 }

--- a/frontend/src/page/LocationPage/views/ModelBlurBGView.js
+++ b/frontend/src/page/LocationPage/views/ModelBlurBGView.js
@@ -1,0 +1,7 @@
+import View from "@/page/View";
+import { qs } from "@/helper/selectHelpers";
+export default class ModalBlurBGView extends View {
+  constructor(element = qs("#modal-blur-bg")) {
+    super(element);
+  }
+}

--- a/frontend/src/page/MenuPage/Store.js
+++ b/frontend/src/page/MenuPage/Store.js
@@ -6,5 +6,6 @@ export default class Store {
     this.chatRoomListItems = [];
     this.interestProducts = [];
     this.salingProducts = [];
+    this.settingProductId = null;
   }
 }

--- a/frontend/src/page/MenuPage/index.js
+++ b/frontend/src/page/MenuPage/index.js
@@ -11,8 +11,8 @@ import { qs } from "@/helper/selectHelpers";
 
 import "@/public/css/menu.css";
 import Store from "./Store";
-
-const tag = "[MenuPage]";
+import SettingMenuModalView from "./views/SettingMenuModalView";
+import ModalBlurBGView from "./views/ModelBlurBGView";
 
 export default class MenuPage extends AbstractPage {
   constructor(params) {
@@ -40,9 +40,14 @@ export default class MenuPage extends AbstractPage {
         </div>
     </div>
     <div id="modal-blur-bg" class="blur-bg"></div>
-    <div id="setting-menu-modal" class="modal">
-      <div id="setting-edit-btn">수정</div>
-      <div id="setting-delete-btn">삭제</div>  
+    <div id="setting-menu-modal" class="action-modal">
+      <div class="action-modal--menu">
+        <div id="setting-edit-btn" class="action-modal--menu--item">수정</div>
+        <div id="setting-delete-btn" class="action-modal--menu--item">삭제</div>  
+      </div>
+      <div class="action-modal--cancel">
+        취소
+      </div>
     </div>
     `;
   }
@@ -50,29 +55,35 @@ export default class MenuPage extends AbstractPage {
   async after_render() {
     const store = new Store();
 
-    const views = {
-      tabView: new TabView(),
-
-      salingProductListView: new ProductListView(qs("#product-list-window"), {
+    const salingProductListView = new ProductListView(
+      qs("#product-list-window"),
+      {
         showInterestBtn: false,
         showSettingBtn: true,
         showChatMark: true,
         showInterestMark: false,
         emptyMessage: "등록한 상품이 없습니다.",
-      }),
+      }
+    );
 
-      interestProductListView: new ProductListView(
-        qs("#interest-list-window"),
-        {
-          showInterestBtn: true,
-          showSettingBtn: false,
-          showChatMark: true,
-          showInterestMark: false,
-          emptyMessage: "관심을 표시한 상품이 없습니다.",
-        }
-      ),
+    const interestProductListView = new ProductListView(
+      qs("#interest-list-window"),
+      {
+        showInterestBtn: true,
+        showSettingBtn: false,
+        showChatMark: true,
+        showInterestMark: false,
+        emptyMessage: "관심을 표시한 상품이 없습니다.",
+      }
+    );
+
+    const views = {
+      tabView: new TabView(),
+      salingProductListView,
+      interestProductListView,
       chatRoomListView: new ChatRoomListView(),
-      //TODO: Chat View
+      settingMenuModalView: new SettingMenuModalView(),
+      modalBlurBGView: new ModalBlurBGView(),
     };
 
     new Controller(store, views);

--- a/frontend/src/page/MenuPage/views/ModelBlurBGView.js
+++ b/frontend/src/page/MenuPage/views/ModelBlurBGView.js
@@ -1,0 +1,14 @@
+import View from "@/page/View";
+import { qs } from "@/helper/selectHelpers";
+import { on } from "@/helper/eventHelpers";
+export default class ModalBlurBGView extends View {
+  constructor(element = qs("#modal-blur-bg")) {
+    super(element);
+    this.bindingEvents();
+  }
+  bindingEvents() {
+    on(this.element, "click", () => {
+      this.emit("@outfocus-modal");
+    });
+  }
+}

--- a/frontend/src/page/MenuPage/views/SaleProudctSettingModalView.js
+++ b/frontend/src/page/MenuPage/views/SaleProudctSettingModalView.js
@@ -1,8 +1,0 @@
-import { qs } from "@/helper/selectHelpers";
-import View from "@/page/View";
-
-export default class SaleProductSettingModalView extends View {
-  constructor(element = qs("#setting-menu-modal")) {
-    super(element);
-  }
-}

--- a/frontend/src/page/MenuPage/views/SaleProudctSettingModalView.js
+++ b/frontend/src/page/MenuPage/views/SaleProudctSettingModalView.js
@@ -1,0 +1,8 @@
+import { qs } from "@/helper/selectHelpers";
+import View from "@/page/View";
+
+export default class SaleProductSettingModalView extends View {
+  constructor(element = qs("#setting-menu-modal")) {
+    super(element);
+  }
+}

--- a/frontend/src/page/MenuPage/views/SettingMenuModalView.js
+++ b/frontend/src/page/MenuPage/views/SettingMenuModalView.js
@@ -1,0 +1,27 @@
+import { qs } from "@/helper/selectHelpers";
+import { on } from "@/helper/eventHelpers";
+import ModalView from "@/common/views/ModalView";
+
+export default class SettingMenuModalView extends ModalView {
+  constructor(element = qs("#setting-menu-modal")) {
+    super(element);
+    this.editButtonElement = qs("#setting-edit-btn", this.element);
+    this.deleteButtomElement = qs("#setting-delete-btn", this.element);
+    this.cancelButtonElement = qs(".action-modal--cancel", this.element);
+    this.bindingEvents();
+  }
+
+  bindingEvents() {
+    on(this.editButtonElement, "click", () => {
+      this.emit("@edit");
+    });
+
+    on(this.deleteButtomElement, "click", () => {
+      this.emit("@delete");
+    });
+
+    on(this.cancelButtonElement, "click", () => {
+      this.emit("@cancel");
+    });
+  }
+}

--- a/frontend/src/public/css/common/modal.css
+++ b/frontend/src/public/css/common/modal.css
@@ -1,5 +1,5 @@
 .blur-bg {
-  visibility: hidden;
+  display: block;
   position: absolute;
   left: 0;
   top: 0;
@@ -10,10 +10,9 @@
 }
 
 .modal {
-  visibility: hidden;
+  display: flex;
   padding: 16px 20px;
   position: absolute;
-  display: flex;
   flex-direction: column;
   left: 50%;
   top: 50%;

--- a/frontend/src/public/css/common/modal.css
+++ b/frontend/src/public/css/common/modal.css
@@ -1,14 +1,3 @@
-.blur-bg {
-  display: block;
-  position: absolute;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  background-color: black;
-  opacity: 0.5;
-}
-
 .modal {
   display: flex;
   padding: 16px 20px;
@@ -84,4 +73,81 @@
   background-color: #f6f6f6;
   box-shadow: 0px 0px 4px rgba(204, 204, 204, 0.5),
     0px 2px 4px rgba(0, 0, 0, 0.25);
+}
+
+@keyframes spring-show-effect {
+  from {
+    bottom: 0%;
+  }
+  to {
+    bottom: 5%;
+  }
+}
+
+.action-modal {
+  left: 50%;
+  bottom: 5%;
+  transform: translate(-50%);
+  position: absolute;
+  width: 288px;
+  animation-name: spring-show-effect;
+  animation-duration: 0.5s;
+}
+
+.action-modal--menu {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  border-radius: 8px;
+  background-color: #f6f6f6;
+  box-shadow: 0px 0px 4px rgba(204, 204, 204, 0.5),
+    0px 2px 4px rgba(0, 0, 0, 0.25);
+}
+
+.action-modal--menu--item {
+  padding-top: 20px;
+  padding-bottom: 20px;
+  text-align: center;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.action-modal--menu--item:not(:last-child) {
+  border-bottom: 1px solid #c0c0c0;
+}
+
+.action-modal--cancel {
+  margin-top: 20px;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  text-align: center;
+  border-radius: 8px;
+  background-color: #f6f6f6;
+  box-shadow: 0px 0px 4px rgba(204, 204, 204, 0.5),
+    0px 2px 4px rgba(0, 0, 0, 0.25);
+  font-size: 14px;
+  font-weight: 500;
+  color: red;
+}
+
+@keyframes blur-show-effect {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 0.5;
+  }
+}
+
+.blur-bg {
+  display: block;
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: black;
+  opacity: 0.5;
+  animation-name: blur-show-effect;
+  animation-duration: 0.5s;
 }


### PR DESCRIPTION

## 개요

메뉴 탭에서 자기가 판매중인 상품리스트의 아이템에서 메뉴 아이콘을 누르면 모달창이 등장하도록 구현했습니다.

## 변경사항

- `GET /api/account/me` API에 AuthMiddleware를 제거했습니다. 아무래로 인증이되지않았다는 응답자체도 기능으로 봐도 무방했고 에러라고 취급하기보다는 저희 어플리케이션의 기능 중 일부라고 생각했기에 /api/account/me 만을 제외하고 다른 API에 직접 인증 미들웨어를 추가했습니다.

- View를 상속받는 ModalView를 만들어서 다른 ModalView들이 상속받도록했습니다.

modal은 일반 모달들과 달리 visibility로 DOM을 처리하기 때문에 `show`, `hide` 메소드를 재정의했습니다.
 
## 참고사항
## 추가 구현 필요사항
수정하기 화면이 완료되면 해당 모달의 `@edit` 커스텀 이벤트 에 대해서 처리하는 로직을 완성해야합니다.

## 스크린샷
![Uploading 스크린샷 2021-07-22 오후 10.59.35.png…]()

